### PR TITLE
fixes issue #60

### DIFF
--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -12,6 +12,13 @@ const DraftOrcaDashboard = () => {
   const [useTotalLines, setUseTotalLines] = useState([]);
   const [totalLines, setTotalLines] = useState([]);
   const [showCard, setShowCard] = useState(false);
+  const [sameCriteria, setSameCriteria] = useState(false);
+
+  const [searchQueryData, setSearchQueryData] = useState({
+    searchTerms: [], 
+    specifyLines: [],
+    sections: [],
+  });
 
   const onFileSelected = (event) => {
     const selectedFile = event.target.files[0];
@@ -87,14 +94,12 @@ const DraftOrcaDashboard = () => {
     }
     else{
       setShowCard(true)
+      setSearchQueryData({
+        searchTerms: searchTerms,
+        specifyLines: specifyLines,
+        sections: sections,
+      });
     }
-    const search_query_data = {
-      file_path: fileName.toString(),
-      search_terms: searchTerms,
-      sections: sections,
-      specify_lines: specifyLines.join(','),
-    };
-
   };
 
   const downloadDocument = (blob) => {
@@ -121,10 +126,24 @@ const DraftOrcaDashboard = () => {
     });
   };
 
-  const [sameCriteria, setSameCriteria] = useState(false);
+  
 
   const handleSameCriteriaChange = (e) => {
     setSameCriteria(e.target.checked);
+  };
+
+  const handleDelete = () => {
+    setSearchQueryData({
+      searchTerms: [], 
+      specifyLines: [],
+      sections: [],
+    });
+    setSearchTerms([]);
+    setSpecifyLines([]);
+    setSections([]);
+    setUseTotalLines([]);
+    setTotalLines([]);
+    setShowCard(false);
   };
 
   return (
@@ -249,7 +268,7 @@ const DraftOrcaDashboard = () => {
               <p className="card-text">Sections: {sections.join(', ')}</p>
               <div className="d-flex justify-content-end">
                 <button className="btn btn-primary me-2">Edit</button>
-                <button className="btn btn-danger">Delete</button>
+                <button className="btn btn-danger" onClick={handleDelete}>Delete</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Fixes #60

**What was changed?**

*I added and modified the handleDelete function in the DraftOrcaDashboard component. This function was created to manage the deletion of the search query card and to ensure that the input fields are reset when the card is deleted.*

**Why was it changed?**

*Initially, the DraftOrcaDashboard component failed to reset the input fields when the search query card was deleted. When the "Delete" button was clicked, nothing happened. To address this, I created the handleFunction button and modified it to both remove the search query card and also clear the search input fields to ensure a seamless experience.*

**How was it changed?**

*It was changed through the creation of the handleDelete function and modification to reset the input fields.*
<img width="259" alt="handleDelete function" src="https://github.com/user-attachments/assets/1a9bc186-8614-42ba-8b21-03bbc0f68848">

Note: I realize the wrong branch was used to commit the changes. I will delete and use the correct branch names for future pull requests. 