### PR TITLE
Implemented the Delete functionality in the Search Query (#60) fixed

### DIFF
--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -322,4 +322,3 @@ const DraftOrcaDashboard = () => {
 };
 
 export default DraftOrcaDashboard;
-

--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -15,6 +15,13 @@ const DraftOrcaDashboard = () => {
   const isSearchTermsEmpty = searchTerms.length === 0;
   const isSpecifyLinesEmpty = specifyLines.length === 0;
   const isSectionsEmpty = sections.length === 0;
+  const [sameCriteria, setSameCriteria] = useState(false);
+
+  const [searchQueryData, setSearchQueryData] = useState({
+    searchTerms: [],
+    specifyLines: [],
+    sections: [],
+  });
   
 
   const onFileSelected = (event) => {
@@ -125,14 +132,12 @@ const DraftOrcaDashboard = () => {
     }
     else{
       setShowCard(true)
+      setSearchQueryData({
+        searchTerms: searchTerms,
+        specifyLines: specifyLines,
+        sections: sections,
+      });
     }
-    const search_query_data = {
-      file_path: fileName.toString(),
-      search_terms: searchTerms,
-      sections: sections,
-      specify_lines: specifyLines.join(','),
-    };
-
   };
 
   const downloadDocument = (blob) => {
@@ -159,10 +164,23 @@ const DraftOrcaDashboard = () => {
     });
   };
 
-  const [sameCriteria, setSameCriteria] = useState(false);
+
 
   const handleSameCriteriaChange = (e) => {
     setSameCriteria(e.target.checked);
+  };
+
+  const handleDelete = () => {
+    setSearchQueryData({
+      searchTerms: [], 
+      specifyLines: [],
+      sections: [],
+    });
+    setSearchTerms([]);
+    setSpecifyLines([]);
+    setSections([]);
+    setShowCard(false);
+    setSameCriteria(false);
   };
 
   return (
@@ -277,7 +295,7 @@ const DraftOrcaDashboard = () => {
               <p className="card-text">Sections: {sections.join(', ')}</p>
               <div className="d-flex justify-content-end">
                 <button className="btn btn-primary me-2">Edit</button>
-                <button className="btn btn-danger">Delete</button>
+                <button className="btn btn-danger" onClick={handleDelete}>Delete</button>
               </div>
             </div>
           </div>

--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -17,13 +17,6 @@ const DraftOrcaDashboard = () => {
   const isSectionsEmpty = sections.length === 0;
   const [sameCriteria, setSameCriteria] = useState(false);
 
-  const [searchQueryData, setSearchQueryData] = useState({
-    searchTerms: [],
-    specifyLines: [],
-    sections: [],
-  });
-  
-
   const onFileSelected = (event) => {
     const selectedFile = event.target.files[0];
     setSelectedFile(selectedFile);
@@ -132,11 +125,6 @@ const DraftOrcaDashboard = () => {
     }
     else{
       setShowCard(true)
-      setSearchQueryData({
-        searchTerms: searchTerms,
-        specifyLines: specifyLines,
-        sections: sections,
-      });
     }
   };
 
@@ -171,11 +159,6 @@ const DraftOrcaDashboard = () => {
   };
 
   const handleDelete = () => {
-    setSearchQueryData({
-      searchTerms: [], 
-      specifyLines: [],
-      sections: [],
-    });
     setSearchTerms([]);
     setSpecifyLines([]);
     setSections([]);


### PR DESCRIPTION
Fixes #60

What was changed?

I implemented a handleDelete function within the DraftOrcaDashboard component. This function is responsible for removing the search query card and resetting the associated input fields when the "Delete" button is clicked, ensuring the user has a seamless experience.

Why was it changed?

Previously, deleting a search query card did not reset the corresponding input fields, leading to confusion. Clicking the "Delete" button had no visible effect, which disrupted the expected functionality. This change was made to fix the issue and provide clearer user feedback when deleting a search query.

How was it changed?

The code was updated by adding the handleDelete function. This function handles two tasks: removing the search query card from the interface and resetting the input fields to their default state. By integrating both actions, the component now behaves as intended when the user deletes a query card.