### PR TITLE
[bug]: file name show on windows fix (#73)

### DIFF
--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -181,7 +181,7 @@ const DraftOrcaDashboard = () => {
               className="form-control"
               onChange={onFileSelected}
               accept=".txt"
-              value=''
+              value={fileName}
               aria-label="Upload ORCA data file"
             />
             <button className="btn btn-primary" onClick={onUpload}>


### PR DESCRIPTION
Fixes #73 

**What was changed?**
showing file name instead of file path for windows.

*Here, describe what part of the application you changed (e.g. login page, database, etc.). If possible, mention what specific components were added, removed, or modified.*
`client-app/src/components/DraftOrcaDashboard.js` modified.

*Here, describe the issue that you are fixing with this code, and why your code fixes it.*
Input box was showing file path in windows system instead of file name, so I changed the input value, which will now show the file name.