### PR TITLE
Dropdown and Custom selection for Section field

### DIFF
--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -17,7 +17,7 @@ const DraftOrcaDashboard = () => {
   const isSectionsEmpty = sections.length === 0;
   const [sameCriteria, setSameCriteria] = useState(false);
   const [previewContent, setPreviewContent] = useState("");
-  const [showPreviewModal, setShowPreviewModal] = useState(false); 
+  const [showPreviewModal, setShowPreviewModal] = useState(false);
   const [sectionType, setSectionType] = useState("SELECT");
   const [customSections, setCustomSections] = useState("");
 
@@ -77,6 +77,13 @@ const DraftOrcaDashboard = () => {
     );
   };
 
+  const formatSpecifyLines = () => {
+    const line = specifyLines[0];
+    return line.value === "WHOLE" || line.value === "SELECT" 
+      ? line.value 
+      : `${line.value} ${line.lineNumber}`;
+   };
+
   const onUpload = () => {
     if (!selectedFile) {
       console.error("No file selected");
@@ -99,7 +106,6 @@ const DraftOrcaDashboard = () => {
   };
 
   const removeUploadedFile = (filePath) => {
-    // You can add logic here to delete the file from the server if needed
     setUploadedFiles((prevUploadedFiles) => prevUploadedFiles.filter((file) => file !== filePath));
   };
 
@@ -168,12 +174,12 @@ const DraftOrcaDashboard = () => {
       alert("Please select a file.");
       return;
     }
-  
+
     const data = {
       file_path: filePath.toString(),
       search_terms: searchTerms,
       sections: sections,
-      specify_lines: "FIRST 5",
+      specify_lines: formatSpecifyLines()
     };
 
     axios
@@ -183,7 +189,6 @@ const DraftOrcaDashboard = () => {
       .then((response) => {
         const blob = new Blob([response.data]);
         downloadDocument(blob);
-        // setShowCard(true); // Set showCard to true after successful submission
       })
       .catch((error) => {
         console.error("Error:", error);
@@ -241,13 +246,13 @@ const DraftOrcaDashboard = () => {
       alert("Please select a file.");
       return;
     }
-  
+
     const data = {
       file_path: filePath.toString(),
       search_terms: searchTerms,
       sections: sections,
-      specify_lines: specifyLines.toString(),
-    };  
+      specify_lines: formatSpecifyLines()
+    };
 
     axios
       .post("http://localhost:5001/preview", data)
@@ -336,8 +341,6 @@ const DraftOrcaDashboard = () => {
         </div>
 
         {renderSectionSelection()}
-
-
 
         <div className="button-container">
           <button

--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -8,7 +8,7 @@ const DraftOrcaDashboard = () => {
   const [filePath, setFilePath] = useState("");
   const [searchTerms, setSearchTerms] = useState([]);
   const [specifyLines, setSpecifyLines] = useState([]);
-  const [sections, setSections] = useState([]);
+  const [sections, setSections] = useState();
   const [showCard, setShowCard] = useState(false);
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const isUploadedFilesEmpty = uploadedFiles.length === 0;
@@ -105,9 +105,11 @@ const DraftOrcaDashboard = () => {
 
     const data = {
       file_path: filePath.toString(),
-      search_terms: searchTerms,
-      sections: sections,
-      specify_lines: formatSpecifyLines()
+      search_terms: searchTerms.split(","),
+      sections: sections.type === "Custom"
+        ? sections.value.split(",") // Convert custom value into an array
+        : sections.value.split(","), // Handle First/Last consistently
+      specify_lines: specifyLines.toString(),
     };
 
     axios
@@ -177,9 +179,11 @@ const DraftOrcaDashboard = () => {
 
     const data = {
       file_path: filePath.toString(),
-      search_terms: searchTerms,
-      sections: sections,
-      specify_lines: formatSpecifyLines()
+      search_terms: searchTerms.split(","),
+      sections: sections.type === "Custom"
+        ? sections.value.split(",") // Convert custom value into an array
+        : sections.value.split(","), // Handle First/Last consistently
+      specify_lines: specifyLines.toString(),
     };
 
     axios
@@ -269,15 +273,42 @@ const DraftOrcaDashboard = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Number of sections?</span>
-          <input
-            type="text"
-            className="form-control"
-            placeholder="ex: 1-5 or 1,2,5"
-            value={sections.join(", ")}
-            onChange={(e) => setSections(e.target.value.split(",").map((val) => val.trim()))}
-          />
-        </div>
+  <span>Number of sections?</span>
+  <select
+  className="form-select mb-2"
+  value={sections.type || "Custom"} // Bind the value to sections.type
+  onChange={(e) => {
+    const selectedValue = e.target.value;
+    if (selectedValue === "First") {
+      setSections({ type: "First", value: "1" }); // Consistent object format
+    } else if (selectedValue === "Last") {
+      setSections({ type: "Last", value: "0" }); // Consistent object format
+    } else {
+      setSections({ type: "Custom", value: "" }); // Clear for custom input
+    }
+  }}
+>
+  <option value="First">First</option>
+  <option value="Last">Last</option>
+  <option value="Custom">Custom</option>
+</select>
+
+{/* Custom input field */}
+{sections.type === "Custom" && (
+  <input
+    type="text"
+    className="form-control"
+    placeholder="Enter custom sections (e.g., 1-5 or 1,3,5)"
+    value={sections.value} // Bind to sections.value
+    onChange={(e) =>
+      setSections({ type: "Custom", value: e.target.value.trim() })
+    }
+  />
+)}
+
+</div>
+
+
 
         <div className="button-container">
           <button

--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -107,8 +107,8 @@ const DraftOrcaDashboard = () => {
       file_path: filePath.toString(),
       search_terms: searchTerms.split(","),
       sections: sections.type === "Custom"
-        ? sections.value.split(",") // Convert custom value into an array
-        : sections.value.split(","), // Handle First/Last consistently
+        ? sections.value.split(",")
+        : sections.value.split(","),
       specify_lines: specifyLines.toString(),
     };
 
@@ -181,8 +181,8 @@ const DraftOrcaDashboard = () => {
       file_path: filePath.toString(),
       search_terms: searchTerms.split(","),
       sections: sections.type === "Custom"
-        ? sections.value.split(",") // Convert custom value into an array
-        : sections.value.split(","), // Handle First/Last consistently
+        ? sections.value.split(",")
+        : sections.value.split(","),
       specify_lines: specifyLines.toString(),
     };
 
@@ -273,40 +273,38 @@ const DraftOrcaDashboard = () => {
         </div>
 
         <div className="mb-3 text-start">
-  <span>Number of sections?</span>
-  <select
-  className="form-select mb-2"
-  value={sections.type || "Custom"} // Bind the value to sections.type
-  onChange={(e) => {
-    const selectedValue = e.target.value;
-    if (selectedValue === "First") {
-      setSections({ type: "First", value: "1" }); // Consistent object format
-    } else if (selectedValue === "Last") {
-      setSections({ type: "Last", value: "0" }); // Consistent object format
-    } else {
-      setSections({ type: "Custom", value: "" }); // Clear for custom input
-    }
-  }}
->
-  <option value="First">First</option>
-  <option value="Last">Last</option>
-  <option value="Custom">Custom</option>
-</select>
+          <span>Number of sections?</span>
+          <select
+            className="form-select mb-2"
+            value={sections.type || "Custom"} 
+            onChange={(e) => {
+              const selectedValue = e.target.value;
+              if (selectedValue === "First") {
+                setSections({ type: "First", value: "1" }); 
+              } else if (selectedValue === "Last") {
+                setSections({ type: "Last", value: "0" }); 
+              } else {
+                setSections({ type: "Custom", value: "" }); 
+              }
+            }}
+          >
+            <option value="First">First</option>
+            <option value="Last">Last</option>
+            <option value="Custom">Custom</option>
+          </select>
 
-{/* Custom input field */}
-{sections.type === "Custom" && (
-  <input
-    type="text"
-    className="form-control"
-    placeholder="Enter custom sections (e.g., 1-5 or 1,3,5)"
-    value={sections.value} // Bind to sections.value
-    onChange={(e) =>
-      setSections({ type: "Custom", value: e.target.value.trim() })
-    }
-  />
-)}
-
-</div>
+          {sections.type === "Custom" && (
+          <input
+            type="text"
+            className="form-control"
+            placeholder="Enter custom sections (e.g., 1-5 or 1,3,5)"
+            value={sections.value}
+            onChange={(e) =>
+              setSections({ type: "Custom", value: e.target.value.trim() })
+            }
+          />
+          )}
+        </div>
 
 
 

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -46,7 +46,9 @@ const OrcaDashboardComponent = () => {
     const data = {
       file_path: filePath.toString(),
       search_terms: searchTerms.split(","),
-      sections: sections.split(","),
+      sections: sections.type === "Custom"
+        ? sections.value.split(",") // Convert custom value into an array
+        : sections.value.split(","), // Handle First/Last consistently
       specify_lines: specifyLines.toString(),
     };
 
@@ -84,7 +86,9 @@ const OrcaDashboardComponent = () => {
     const data = {
       file_path: filePath.toString(),
       search_terms: searchTerms.split(","),
-      sections: sections.split(","),
+      sections: sections.type === "Custom"
+        ? sections.value.split(",") // Convert custom value into an array
+        : sections.value.split(","), // Handle First/Last consistently
       specify_lines: specifyLines.toString(),
     };
 
@@ -144,15 +148,37 @@ const OrcaDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Number of sections?</span>
-          <input
-            type="text"
-            className="form-control"
-            placeholder="Input as number..."
-            value={sections}
-            onChange={(e) => setSections(e.target.value)}
-          />
-        </div>
+  <span>Number of sections?</span>
+  <select
+  className="form-select mb-2"
+  value={sections.type || "Custom"} 
+  onChange={(e) => {
+    const selectedValue = e.target.value;
+    if (selectedValue === "First") {
+      setSections({ type: "First", value: "1" }); 
+    } else if (selectedValue === "Last") {
+      setSections({ type: "Last", value: "0" }); 
+    } else {
+      setSections({ type: "Custom", value: "" }); 
+    }
+  }}>
+  <option value="First">First</option>
+  <option value="Last">Last</option>
+  <option value="Custom">Custom</option>
+</select>
+{sections.type === "Custom" && (
+  <input
+    type="text"
+    className="form-control"
+    placeholder="Enter custom sections (e.g., 1-5 or 1,3,5)"
+    value={sections.value} 
+    onChange={(e) =>
+      setSections({ type: "Custom", value: e.target.value.trim() })
+    }
+  />
+)}
+</div>
+
 
         <div className="mb-3 text-start">
           <span>Use total lines?</span>

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -47,8 +47,8 @@ const OrcaDashboardComponent = () => {
       file_path: filePath.toString(),
       search_terms: searchTerms.split(","),
       sections: sections.type === "Custom"
-        ? sections.value.split(",") // Convert custom value into an array
-        : sections.value.split(","), // Handle First/Last consistently
+        ? sections.value.split(",") 
+        : sections.value.split(","),
       specify_lines: specifyLines.toString(),
     };
 
@@ -87,8 +87,8 @@ const OrcaDashboardComponent = () => {
       file_path: filePath.toString(),
       search_terms: searchTerms.split(","),
       sections: sections.type === "Custom"
-        ? sections.value.split(",") // Convert custom value into an array
-        : sections.value.split(","), // Handle First/Last consistently
+        ? sections.value.split(",")
+        : sections.value.split(","), 
       specify_lines: specifyLines.toString(),
     };
 
@@ -148,36 +148,39 @@ const OrcaDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-  <span>Number of sections?</span>
-  <select
-  className="form-select mb-2"
-  value={sections.type || "Custom"} 
-  onChange={(e) => {
-    const selectedValue = e.target.value;
-    if (selectedValue === "First") {
-      setSections({ type: "First", value: "1" }); 
-    } else if (selectedValue === "Last") {
-      setSections({ type: "Last", value: "0" }); 
-    } else {
-      setSections({ type: "Custom", value: "" }); 
-    }
-  }}>
-  <option value="First">First</option>
-  <option value="Last">Last</option>
-  <option value="Custom">Custom</option>
-</select>
-{sections.type === "Custom" && (
-  <input
-    type="text"
-    className="form-control"
-    placeholder="Enter custom sections (e.g., 1-5 or 1,3,5)"
-    value={sections.value} 
-    onChange={(e) =>
-      setSections({ type: "Custom", value: e.target.value.trim() })
-    }
-  />
-)}
-</div>
+          <span>Number of sections?</span>
+          <select
+            className="form-select mb-2"
+            value={sections.type || "Custom"} 
+            onChange={(e) => {
+              const selectedValue = e.target.value;
+              if (selectedValue === "First") {
+                  setSections({ type: "First", value: "1" }); 
+              } else if (selectedValue === "Last") {
+                  setSections({ type: "Last", value: "0" }); 
+              } else {
+                  setSections({ type: "Custom", value: "" }); 
+              }
+            }}
+          >
+            <option value="First">First</option>
+            <option value="Last">Last</option>
+            <option value="Custom">Custom</option>
+          </select>
+
+          {sections.type === "Custom" && (
+          <input
+            type="text"
+            className="form-control"
+            placeholder="Enter custom sections (e.g., 1-5 or 1,3,5)"
+            value={sections.value} 
+            onChange={(e) =>
+              setSections({ type: "Custom", value: e.target.value.trim() })
+            }
+          />
+          )}
+
+        </div>
 
 
         <div className="mb-3 text-start">


### PR DESCRIPTION
Fixes #91

**What was changed?**

*Changed default input field type in sections field to select options with first, last and custom as options. and data field in onSubmit and fetchDocumentPreview the sections is changed to so that objects is converted to array and match the backend data fields*

**Why was it changed?**

*#91 issue is to have a dropdown feature for sections field with first, last and custom as options. whereas first gives section 1 data, last gives last sections data and custom is similar to earlier input field where we can give 1,2,3... or range of values (1-5) .*

**How was it changed?**

*files that I changed: in client-app->src->components->(DraftOrcaDashboard.js and OrcaDashboardComponents.js) files.
exact sections and lines of code where I changed:
in DraftOrcaDashboard.js:
onSubmit and fetchDocumentPreview part  
const data = {}
lines changed: 100 - 107 and 175 - 182
and
Number of sections? 
from single input filed to dropdown options first, last and custom (when custom selected new input field to enter sections will be created.
lines changed: 270 - 302)

same changes are made in OrcaDashboardComponent.js file
onSubmit and fetchDocumentPreview lines changed: 40 - 53; 80 - 93
Number of sections? lines changed: 150 - 183*

**Screenshots that show the changes (if applicable):**
