### PR TITLE
Implemented model for preview output

### DIFF
--- a/client-app/package-lock.json
+++ b/client-app/package-lock.json
@@ -33,7 +33,8 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "msw": "^2.2.13"
+        "msw": "^2.2.13",
+        "prettier": "^3.2.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -15672,6 +15673,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/client-app/src/_test_/ModelBehaviour.test.js
+++ b/client-app/src/_test_/ModelBehaviour.test.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import OrcaDashboardComponent from "../components/OrcaDashboardComponent";
+
+
+jest.mock("axios", () => ({
+  post: jest.fn(),
+}));
+
+describe("OrcaDashboardComponent - Modal Behavior", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  
+  test("Pressing Escape key closes the modal", async () => {
+    render(<OrcaDashboardComponent />);
+
+    // Mock the API call
+    const mockAxios = require("axios");
+    mockAxios.post.mockResolvedValueOnce({
+      data: { document_content: "Preview content for testing." },
+    });
+
+    const previewButton = screen.getByRole("button", { name: /Preview Output/i });
+    fireEvent.click(previewButton);
+
+    await waitFor(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(screen.queryByText("Document Preview")).not.toBeInTheDocument();
+    });
+  }); 
+  
+})

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { saveAs } from "file-saver";
 import "../styles/DashboardComponent.css";
@@ -12,6 +12,22 @@ const OrcaDashboardComponent = () => {
   const [useTotalLines, setUseTotalLines] = useState("");
   const [totalLines, setTotalLines] = useState("");
   const [previewContent, setPreviewContent] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+
+  useEffect(() => {
+    const handleEscapeKey = (event) => {
+      if (event.key === "Escape") {
+        setIsModalOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscapeKey);
+    return () => {
+      document.removeEventListener("keydown", handleEscapeKey);
+    };
+  }, []);
+
 
   const onFileSelected = (event) => {
     setSelectedFile(event.target.files[0]);
@@ -76,10 +92,10 @@ const OrcaDashboardComponent = () => {
   };
 
   const fetchDocumentPreview = () => {
-    if (!selectedFile) {
-      alert("Please select a file.");
-      return;
-    }
+     if (!selectedFile) {
+       alert("Please select a file.");
+       return;
+     }
 
     const data = {
       file_path: filePath.toString(),
@@ -95,17 +111,43 @@ const OrcaDashboardComponent = () => {
     if (totalLines) {
       data.total_lines = totalLines;
     }
-
-    axios
-      .post("http://localhost:5001/preview", data)
-      .then((response) => {
-        const documentContent = response.data.document_content;
-        setPreviewContent(documentContent);
-      })
-      .catch((error) => {
-        console.error("Error:", error);
-      });
+    console.log(data)
+    // Simulated response
+  const mockResponse = {
+    data: {
+      document_content: `Preview of document content for file: ${data.file_path}
+      Search Terms: ${data.search_terms.join(", ")}
+      Sections: ${data.sections.join(", ")}
+      Specify Lines: ${data.specify_lines}
+      Total Lines: ${data.use_total_lines ? data.total_lines : "Not Specified"}`,
+    },
   };
+
+  // Simulate the response handling
+  try {
+    const documentContent = mockResponse.data.document_content;
+    console.log("Mock Response:", mockResponse);
+    setPreviewContent(documentContent);
+    setIsModalOpen(true);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+};
+
+
+  //   axios
+  //     .post("http://localhost:5001/preview", data)
+  //     .then((response) => {
+  //       const documentContent = response.data.document_content;
+
+  //       console.log(response)
+  //       setPreviewContent(documentContent);
+  //       setIsModalOpen(true);
+  //     })
+  //     .catch((error) => {
+  //       console.error("Error:", error);
+  //     });
+  // };
 
   return (
     <div className="container py-5 d-flex justify-content-center">
@@ -187,14 +229,29 @@ const OrcaDashboardComponent = () => {
           </button>
         </div>
 
-        {previewContent && (
+        Modal
+        {isModalOpen && (
+          <div className="modal-overlay">
+            <div className="modal-content">
+              <button className="close-button" onClick={() => setIsModalOpen(false)}>
+                &times;
+              </button>
+              <h3>Document Preview</h3>
+              <div className="preview-box">
+                <pre>{previewContent}</pre>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* {previewContent && (
           <div className="document-preview">
             <h3>Document Preview</h3>
             <div className="preview-box">
               <pre>{previewContent}</pre>
             </div>
           </div>
-        )}
+        )} */}
       </div>
     </div>
   );

--- a/client-app/src/styles/DashboardComponent.css
+++ b/client-app/src/styles/DashboardComponent.css
@@ -194,3 +194,49 @@ span {
         border-color: #0a58ca;
       }
        */
+       .modal-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 1000;
+      }
+      
+      .modal-content {
+        background: white;
+        padding: 20px;
+        border-radius: 8px;
+        width: 80%;
+        max-height: 80%;
+        overflow-y: auto;
+        box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+        position: relative;
+        display: flex;
+        flex-direction: column;
+      }
+      
+      .close-button {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: red;
+        border: none;
+        font-size: 24px;
+        font-weight: bold;
+        cursor: pointer;
+        color: #333;
+      }
+      .close-button:hover {
+        color: #000;
+      }
+      
+      .preview-box {
+        white-space: pre-wrap;
+        word-wrap: break-word;
+      }
+      

--- a/server/application/rest/search_orca_data.py
+++ b/server/application/rest/search_orca_data.py
@@ -27,6 +27,7 @@ def preview_document():
     '''
     data = request.get_json(force=True)
     response = preview_document_use_case(data)
+    console.log(data)
     return Response(
         json.dumps(response.value),
         mimetype="application/json",


### PR DESCRIPTION
Fixes #103 
**What was changed?**

Implemented a modal popup to display the preview data when the "Preview Output" button is clicked.
Added a close button in the top-right corner and Escape key functionality to close the modal.
Made the preview content scrollable for longer outputs.
Centered the modal on the screen with a dimmed background to focus attention.
Replaced the actual API request with a mock response to handle backend unavailability during development.
Added a test case to verify that the modal closes when the Escape key is pressed.

**What was changed?**

Implemented a modal popup in the OrcaDashboardComponent.js to display preview data when the "Preview Output" button is clicked.
Styled the modal and background dimming in DashboardComponent.css.
Added a new test file, ModalBehaviour.test.js, in the _test_ folder to verify closure when the Escape key is pressed.
Replaced the actual API request with a mock response to handle backend unavailability during development.
