### PR TITLE
Added automated frontend testing workflow using GitHub Actions

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,30 @@
+name: UI Testing
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: |
+        cd client-app
+        npm install
+    - name: Run Tests
+      run: |
+        cd client-app
+        npm test

--- a/client-app/src/_test_/UploadFile.test.js
+++ b/client-app/src/_test_/UploadFile.test.js
@@ -23,7 +23,7 @@ describe("DraftOrcaDashboard", () => {
 
     // Mock axios post response
     const mockAxios = require("axios");
-    mockAxios.post.mockResolvedValueOnce({ data: { filename: "test.orca.txt" } });
+    mockAxios.post.mockResolvedValueOnce({ data: { file_name: "test.orca.txt" } });
 
     // Simulate file selection and upload
     fireEvent.change(fileInput, { target: { files: [file] } });


### PR DESCRIPTION
Fixes #80 

**What was changed?**
Added automated frontend testing workflow to the CI/CD pipeline using GitHub Actions.

**Why was it changed?**
The project currently lacks automated running of front-end unit tests in the CI/CD pipeline. This can lead to undetected bugs and regressions in the front-end code. So, added the frontend tests GitHub action script under GitHub workflows

**How was it changed?**
.github/workflows: Added frontend-tests.yml file - The file contains the script to automatically run frontend unit tests on pull requests to the main branch and on pushes to the main branch.