### PR TITLE
#81 added NO data error message

### DIFF
--- a/client-app/src/components/DraftOrcaDashboard.js
+++ b/client-app/src/components/DraftOrcaDashboard.js
@@ -17,7 +17,7 @@ const DraftOrcaDashboard = () => {
   const isSectionsEmpty = sections.length === 0;
   const [sameCriteria, setSameCriteria] = useState(false);
   const [previewContent, setPreviewContent] = useState("");
-  const [showPreviewModal, setShowPreviewModal] = useState(false); 
+  const [showPreviewModal, setShowPreviewModal] = useState(false);
 
   const onFileSelected = (event) => {
     const selectedFile = event.target.files[0];
@@ -67,10 +67,10 @@ const DraftOrcaDashboard = () => {
 
   const formatSpecifyLines = () => {
     const line = specifyLines[0];
-    return line.value === "WHOLE" || line.value === "SELECT" 
-      ? line.value 
+    return line.value === "WHOLE" || line.value === "SELECT"
+      ? line.value
       : `${line.value} ${line.lineNumber}`;
-   };
+  };
 
   const onUpload = () => {
     if (!selectedFile) {
@@ -107,7 +107,7 @@ const DraftOrcaDashboard = () => {
       file_path: filePath.toString(),
       search_terms: searchTerms,
       sections: sections,
-      specify_lines: formatSpecifyLines()
+      specify_lines: formatSpecifyLines(),
     };
 
     axios
@@ -119,7 +119,11 @@ const DraftOrcaDashboard = () => {
         downloadDocument(blob);
       })
       .catch((error) => {
-        console.error("Error:", error);
+        if (error.response && error.response.status === 404) {
+          alert("There is no data for the provided search term");
+        } else {
+          console.error("Error:", error);
+        }
       });
   };
 
@@ -179,17 +183,21 @@ const DraftOrcaDashboard = () => {
       file_path: filePath.toString(),
       search_terms: searchTerms,
       sections: sections,
-      specify_lines: formatSpecifyLines()
+      specify_lines: formatSpecifyLines(),
     };
 
     axios
       .post("http://localhost:5001/preview", data)
       .then((response) => {
-        setPreviewContent(response.data.document_content); 
-        setShowPreviewModal(true); 
+        setPreviewContent(response.data.document_content);
+        setShowPreviewModal(true);
       })
       .catch((error) => {
-        console.error("Error fetching preview:", error);
+        if (error.response && error.response.status === 404) {
+          alert("There is no data for the provided search term");
+        } else {
+          console.error("Error fetching preview:", error);
+        }
       });
   };
 
@@ -322,28 +330,32 @@ const DraftOrcaDashboard = () => {
           <button
             className="btn btn-primary"
             onClick={fetchDocumentPreview}
-              disabled={
-                !searchTerms.length ||
-                !specifyLines.length ||
-                !sections.length ||
-                !selectedFile ||
-                isUploadedFilesEmpty
-              }>
+            disabled={
+              !searchTerms.length ||
+              !specifyLines.length ||
+              !sections.length ||
+              !selectedFile ||
+              isUploadedFilesEmpty
+            }>
             Preview
           </button>
-        </div>    
+        </div>
         {showPreviewModal && (
-          <div className="modal" style={{ display: "block", backgroundColor: "rgba(0, 0, 0, 0.5)" }}>
-            <div className="modal-dialog"  style={{ maxWidth: "80vw"}}>
+          <div
+            className="modal"
+            style={{ display: "block", backgroundColor: "rgba(0, 0, 0, 0.5)" }}>
+            <div className="modal-dialog" style={{ maxWidth: "80vw" }}>
               <div className="modal-content">
                 <div className="modal-header">
                   <h5 className="modal-title">Document Preview</h5>
-                  <button type="button" className="btn-close" aria-label="Close" onClick={() => setShowPreviewModal(false)}></button>
+                  <button
+                    type="button"
+                    className="btn-close"
+                    aria-label="Close"
+                    onClick={() => setShowPreviewModal(false)}></button>
                 </div>
                 <div className="modal-body">
-                <pre>
-                    {previewContent}
-                  </pre>
+                  <pre>{previewContent}</pre>
                 </div>
                 <div className="modal-footer">
                   <button className="btn btn-secondary" onClick={() => setShowPreviewModal(false)}>
@@ -369,7 +381,6 @@ const DraftOrcaDashboard = () => {
             Download Output
           </button>
         </div>
-
       </div>
     </div>
   );

--- a/server/services/file_search_operations.py
+++ b/server/services/file_search_operations.py
@@ -62,6 +62,10 @@ def extract_sections(file_path, search_terms, sections, specify_lines, use_total
                 terms_num += 1
             line_num += 1
 
+    # If no search terms found, return empty string
+    if not term_line_num:
+        return ""
+
     for i in sections:
         section_lines = specify_lines[i-1].split()
         start_line = term_line_num[i-1]

--- a/server/usecases/search_orca_data.py
+++ b/server/usecases/search_orca_data.py
@@ -23,6 +23,8 @@ def preview_document_use_case(data):
         specify_lines = [temp_specify_lines] * len(sections)
         document_content = extract_sections(file_path, search_terms, sections, 
                                             specify_lines, use_total_lines, total_lines)
+        if not document_content:
+            return ResponseFailure(ResponseTypes.NOT_FOUND, 'There is no data for the provided search term')
         return ResponseSuccess({'document_content': document_content})
     except FileNotFoundError as e:
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, f'File not found: {str(e)}')
@@ -30,7 +32,8 @@ def preview_document_use_case(data):
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, f'Permission denied: {str(e)}')
     except ValueError as e:
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, f'Value error: {str(e)}')
-
+    except Exception as e:
+        return ResponseFailure(ResponseTypes.SYSTEM_ERROR, str(e))
 
 def find_sections_use_case(data):
     '''
@@ -53,6 +56,8 @@ def find_sections_use_case(data):
     try:
         document_content = extract_sections(file_path, search_terms, sections, 
                                             specify_lines, use_total_lines, total_lines)
+        if not document_content:
+            return ResponseFailure(ResponseTypes.NOT_FOUND, 'There is no data for the provided search term')
         document = Document()
         for paragraph in document_content.split('\n'):
             document.add_paragraph(paragraph.strip())
@@ -68,3 +73,5 @@ def find_sections_use_case(data):
         return ResponseFailure(ResponseTypes.SYSTEM_ERROR, f'Document processing error: {str(e)}')
     except TypeError as e:
         return ResponseFailure(ResponseTypes.SYSTEM_ERROR, f'Document type error: {str(e)}')
+    except Exception as e:
+        return ResponseFailure(ResponseTypes.SYSTEM_ERROR, str(e))


### PR DESCRIPTION
Fixes #81 

**What was changed?**

*The DraftOrcaDashboard frontend, file_search_operations backend, and usecases/search_orca_data backend logic were modified to handle cases where no search terms or data are found by alerting users and returning appropriate error responses.*

**Why was it changed?**

*These changes were made to improve user experience and error handling by providing feedback when no data matches the provided search terms, ensuring the application responds gracefully.*

**How was it changed?**

- In DraftOrcaDashboard, an alert was added for 404 responses when no data is found.
- In file_search_operations, a check was added to return an empty string if no matching search terms are found.
- In usecases/search_orca_data, error handling was added to return a NOT_FOUND response with a clear message when no content is retrieved.

**Screenshots that show the changes (if applicable):**
![image](https://github.com/user-attachments/assets/b815869e-cd78-4c2d-a4fe-d2ebe16cbe64)
