### PR TITLE
Fixed issue #131: Display 'No Data' error message in UI

### DIFF
--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -120,7 +120,6 @@ const OrcaDashboardComponent = () => {
         downloadDocument(blob);
       })
       .catch((error) => {
-        // console.error("Error:", error);
         if (error.response && error.response.status === 404) {
           alert("There is no data for the provided search term");
         } else {

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -120,7 +120,12 @@ const OrcaDashboardComponent = () => {
         downloadDocument(blob);
       })
       .catch((error) => {
-        console.error("Error:", error);
+        // console.error("Error:", error);
+        if (error.response && error.response.status === 404) {
+          alert("There is no data for the provided search term");
+        } else {
+          console.error("Error:", error);
+        }
       });
   };
 
@@ -199,7 +204,11 @@ const OrcaDashboardComponent = () => {
         setShowPreviewModal(true); 
       })
       .catch((error) => {
-        console.error("Error fetching preview:", error);
+        if (error.response && error.response.status === 404) {
+          alert("There is no data for the provided search term");
+        } else {
+          console.error("Error fetching preview:", error);
+        }
       });
   };
 

--- a/server/services/file_search_operations.py
+++ b/server/services/file_search_operations.py
@@ -62,6 +62,9 @@ def extract_sections(file_path, search_terms, sections, specify_lines, use_total
                 terms_num += 1
             line_num += 1
 
+    if not term_line_num:
+        return ""
+
     for i in sections:
         section_lines = specify_lines[i-1].split()
         start_line = term_line_num[i-1]

--- a/server/usecases/search_orca_data.py
+++ b/server/usecases/search_orca_data.py
@@ -23,6 +23,10 @@ def preview_document_use_case(data):
         specify_lines = [temp_specify_lines] * len(sections)
         document_content = extract_sections(file_path, search_terms, sections, 
                                             specify_lines, use_total_lines, total_lines)
+        
+        if not document_content:
+            return ResponseFailure(ResponseTypes.NOT_FOUND, 'No data found for the provided search term.')
+
         return ResponseSuccess({'document_content': document_content})
     except FileNotFoundError as e:
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, f'File not found: {str(e)}')
@@ -53,6 +57,10 @@ def find_sections_use_case(data):
     try:
         document_content = extract_sections(file_path, search_terms, sections, 
                                             specify_lines, use_total_lines, total_lines)
+        
+        if not document_content:
+            return ResponseFailure(ResponseTypes.NOT_FOUND, 'No data found for the provided search term.')
+
         document = Document()
         for paragraph in document_content.split('\n'):
             document.add_paragraph(paragraph.strip())


### PR DESCRIPTION
Fixes #131 

**What was changed?**

The backend was updated to return a 404 error instead of a 500 error when no data is found. The frontend now displays an alert message to inform users that their search returned no results. 

**Why was it changed?**

Previously, when no data was found, the system returned a 500 Internal Server Error. This confused users because the issue was not a server error but a lack of matching results. The new behavior improves user experience by providing a clear and accurate message.

**How was it changed?**

- The backend (usecases/search_orca_data.py) was updated to return 404 when no data is found
- The search logic (file_search_operations.py) now handles empty results properly
- The frontend (OrcaDashboardComponent.js) now shows an alert when a 404 response is received

**Screenshots that show the changes (if applicable):**

![image](https://github.com/user-attachments/assets/8751f623-134a-4a61-b3aa-8c3f981b60ca)
