### PR TITLE
Add whitespace and fix number of sections deletion

### DIFF
--- a/ESP.app/package-lock.json
+++ b/ESP.app/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "esp.app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -150,7 +150,7 @@ const OrcaDashboardComponent = () => {
     }
   };
 
-  const handleBlur = (e, setterFunc) => {
+  const handleSearchTermBlur = (e, setterFunc) => {
     const value = e.target.value.trim();
     if (value) {
       const values = value.split(",");
@@ -159,6 +159,15 @@ const OrcaDashboardComponent = () => {
     }
   };
 
+  const handleNumSectionsBlur = (e) => {
+    const parsedSections = e.target.value
+    .split(",")
+    .map((val) => val.trim())
+    .filter((val) => val !== "");
+
+  setSections(parsedSections);
+  };
+  
   const removeTag = (index, setterFunc) => {
     setterFunc((prevTerms) => {
       const updatedTerms = [...prevTerms];
@@ -246,7 +255,7 @@ const OrcaDashboardComponent = () => {
               className="form-control"
               placeholder="E.g., CARTESIAN COORDINATES"
               onKeyPress={(e) => handleKeyPress(e, setSearchTerms)}
-              onBlur={(e) => handleBlur(e, setSearchTerms)}
+              onBlur={(e) => handleSearchTermBlur(e, setSearchTerms)}
             />
             {searchTerms.map((term, index) => (
               <span
@@ -285,8 +294,9 @@ const OrcaDashboardComponent = () => {
             type="text"
             className="form-control"
             placeholder="ex: 1-5 or 1,2,5"
-            value={sections.join(", ")}
-            onChange={(e) => setSections(e.target.value.split(",").map((val) => val.trim()))}
+            defaultValue={sections.join(", ")}
+            //onChange={(e) => setSections(e.target.value.split(",").map((val) => val.trim()))}
+            onBlur={handleNumSectionsBlur}
           />
         </div>
 

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -43,6 +43,7 @@ const OrcaDashboardComponent = () => {
       <div className="mb-2 d-flex align-items-center">
         <select
           className="form-select me-2"
+          id="specifyLinesSelect"
           value={line.value}
           onChange={(e) => handleSpecifyLineChange(e.target.value)}>
           <option value="SELECT">SELECT</option>
@@ -217,11 +218,12 @@ const OrcaDashboardComponent = () => {
       <div className="text-center">
         <h2 className="mb-4">Extract data from ORCA files to Word documents</h2>
         <div className="mb-3 text-start">
-          <label className="mb-2">Upload your ORCA data file:</label>
+          <label htmlFor="fileUpload" className="mb-2">Upload your ORCA data file:</label>
           <div className="input-group">
             <input
               type="file"
               className="form-control"
+              id="fileUpload"
               onChange={onFileSelected}
               accept=".txt"
               value=""
@@ -248,11 +250,12 @@ const OrcaDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <label className="mb-2">Enter the terms you wish to search for (txt only):</label>
+          <label htmlFor="searchTermInput" className="mb-2">Enter the terms you wish to search for (txt only):</label>
           <div>
             <input
               type="text"
               className="form-control"
+              id="searchTermInput"
               placeholder="E.g., CARTESIAN COORDINATES"
               onKeyPress={(e) => handleKeyPress(e, setSearchTerms)}
               onBlur={(e) => handleSearchTermBlur(e, setSearchTerms)}
@@ -284,18 +287,18 @@ const OrcaDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <label className="mb-2">Enter how you want the lines specified:</label>
+          <label htmlFor="specifyLinesSelect" className="mb-2">Enter how you want the lines specified:</label>
           {renderSpecifyLine()}
         </div>
 
         <div className="mb-3 text-start">
-          <label className="mb-2">Number of sections?</label>
+          <label htmlFor="numSectionsInput" className="mb-2">Number of sections?</label>
           <input
             type="text"
             className="form-control"
+            id="numSectionsInput"
             placeholder="ex: 1-5 or 1,2,5"
             defaultValue={sections.join(", ")}
-            //onChange={(e) => setSections(e.target.value.split(",").map((val) => val.trim()))}
             onBlur={handleNumSectionsBlur}
           />
         </div>

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -208,7 +208,7 @@ const OrcaDashboardComponent = () => {
       <div className="text-center">
         <h2 className="mb-4">Extract data from ORCA files to Word documents</h2>
         <div className="mb-3 text-start">
-          <span>Upload your ORCA data file</span>
+          <label className="mb-2">Upload your ORCA data file:</label>
           <div className="input-group">
             <input
               type="file"
@@ -225,7 +225,7 @@ const OrcaDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Uploaded Files:</span>
+          <label>Uploaded Files:</label>
           {uploadedFiles.map((file, index) => (
             <span key={index} className="badge bg-secondary me-2 mb-2">
               {file}
@@ -239,7 +239,7 @@ const OrcaDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Enter the terms you wish to search for (txt only):</span>
+          <label className="mb-2">Enter the terms you wish to search for (txt only):</label>
           <div>
             <input
               type="text"
@@ -275,12 +275,12 @@ const OrcaDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Enter how you want the lines specified:</span>
+          <label className="mb-2">Enter how you want the lines specified:</label>
           {renderSpecifyLine()}
         </div>
 
         <div className="mb-3 text-start">
-          <span>Number of sections?</span>
+          <label className="mb-2">Number of sections?</label>
           <input
             type="text"
             className="form-control"

--- a/client-app/src/styles/OrcaDashboardComponent.css
+++ b/client-app/src/styles/OrcaDashboardComponent.css
@@ -16,8 +16,3 @@ span {
 .button-container {
   margin-bottom: 10px;
 }
-
-.input-label {
-  margin-bottom: 10px;
-  text-align: start;
-}

--- a/client-app/src/styles/OrcaDashboardComponent.css
+++ b/client-app/src/styles/OrcaDashboardComponent.css
@@ -16,3 +16,8 @@ span {
 .button-container {
   margin-bottom: 10px;
 }
+
+.input-label {
+  margin-bottom: 10px;
+  text-align: start;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "esp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Fixes [#128](https://github.com/oss-slu/esp/issues/128)

**What was changed?**

Added whitespace between input labels and input fields
Added focusing on input fields by clicking on label
Fixed issue with deletion in number of sections field

**Why was it changed?**

Minimal amounts of whitespace led to messy formatting, and text boxes hard to distinguish and read.
The Number of Sections input field did not allow for the user to use the backspace key to properly delete one input at a time, and instead required the user to delete their entire input.

**How was it changed?**

_For whitespace:_
Edited `OrcaDashboardComponent.js` to have an additional bottom margin on all labels associated with an input field. Additionally, changed text labels from `span` to `label` to allow for proper use of bottom margin.
Added `id` and `htmlFor` attributes to labels and inputs to allow clicking on a label to focus the input field.

_For number of sections deletions:_
Changed the Number of Sections field to update state and format using `onBlur` instead of `onChange`, fixing issue of updating after every input, preventing deletion after a comma is formatted.
Renamed previous `handleOnBlur` to match its use case for more clarity between it and the new `handleNumSectionsBlur`

**Screenshots that show the changes (if applicable):**

Updated Whitespace:
![image](https://github.com/user-attachments/assets/96fffcfd-b28f-44e8-bbf8-61a6f0a2b71d)

Existing Whitespace:
![image](https://github.com/user-attachments/assets/8451fc85-d5cd-48f4-8e3f-885638ee2835)
