### PR TITLE
added multiple search terms

### DIFF
--- a/server/services/file_search_operations.py
+++ b/server/services/file_search_operations.py
@@ -52,72 +52,75 @@ def extract_sections(file_path, search_terms, sections, specify_lines, use_total
 
         return is_end_pattern_flag
 
+    term_line_nums = {term: [] for term in search_terms}  
+
     for term in search_terms:
         line_num = 0
-        term_line_num = []
-        terms_num = 0
         for line in lines:
             if term in line:
-                term_line_num.append(line_num)
-                terms_num += 1
+                term_line_nums[term].append(line_num)
             line_num += 1
 
-    if not term_line_num:
+    if not any(term_line_nums.values()):
         return ""
 
-    for i in sections:
-        section_lines = specify_lines[i-1].split()
-        start_line = term_line_num[i-1]
-        line_empty = 0
-        search_term = search_terms[0]  # Update it when supporting multiple search terms
-        document_content += lines[start_line]
+    for term in search_terms:
+        term_line_num = term_line_nums[term]
+        for i in range(len(sections)):
+            section_lines = specify_lines[i].split()
+            start_line = term_line_num[i] if i < len(term_line_num) else None
+            if start_line is None:
+                continue  # Skip this section if the term is not found
 
-        if section_lines[0].upper() == 'WHOLE' and not use_total_lines:
-            while line_empty == 0:
-                if search_term not in lines[start_line].strip() and is_content_line(
-                            lines[start_line], search_term, header_pattern):
-                    document_content += lines[start_line]
-                if is_end_pattern(lines, start_line):
-                    break
-                start_line += 1
+            line_empty = 0
+            document_content += lines[start_line]
 
-        if section_lines[0].upper() == 'WHOLE' and use_total_lines:
-            for _ in range(total_lines - start_line + term_line_num[i-1]):
-                if search_term not in lines[start_line].strip() and is_content_line(
-                            lines[start_line], search_term, header_pattern):
-                    document_content += lines[start_line]
-                if is_end_pattern(lines, start_line):
-                    break
-                start_line += 1
-                line_empty = 1
+            if section_lines[0].upper() == 'WHOLE' and not use_total_lines:
+                while line_empty == 0:
+                    if term not in lines[start_line].strip() and is_content_line(
+                            lines[start_line], term, header_pattern):
+                        document_content += lines[start_line]
+                    if is_end_pattern(lines, start_line):
+                        break
+                    start_line += 1
 
-        elif section_lines[0].upper() == 'FIRST':
-            line_count = 0
-            while line_count < int(section_lines[1]):
-                if search_term not in lines[start_line].strip() and is_content_line(
-                                                lines[start_line], search_term, header_pattern):
-                    document_content += lines[start_line]
-                    line_count += 1
-                if is_end_pattern(lines, start_line):
-                    break
-                start_line += 1
+            if section_lines[0].upper() == 'WHOLE' and use_total_lines:
+                for _ in range(total_lines - start_line + term_line_num[i]):
+                    if term not in lines[start_line].strip() and is_content_line(
+                            lines[start_line], term, header_pattern):
+                        document_content += lines[start_line]
+                    if is_end_pattern(lines, start_line):
+                        break
+                    start_line += 1
+                    line_empty = 1
 
-        elif section_lines[0].upper() == 'LAST':
-            temp_content = []
-            while start_line < len(lines):
-                if is_end_pattern(lines, start_line):
-                    break
-                if is_content_line(lines[start_line], search_term, header_pattern):
-                    temp_content.append(lines[start_line])
-                start_line += 1
-            document_content += ''.join(temp_content[-int(section_lines[1]):])
+            elif section_lines[0].upper() == 'FIRST':
+                line_count = 0
+                while line_count < int(section_lines[1]):
+                    if term not in lines[start_line].strip() and is_content_line(
+                                                lines[start_line], term, header_pattern):
+                        document_content += lines[start_line]
+                        line_count += 1
+                    if is_end_pattern(lines, start_line):
+                        break
+                    start_line += 1
 
-        elif section_lines[0].upper() == 'SPECIFIC':
-            specific_lines = [int(l) for l in section_lines[1].split(",")]
-            for l in specific_lines:
-                if start_line + l < len(lines) and not is_end_pattern(lines, start_line + l):
-                    if is_content_line(lines[start_line + l], search_term, header_pattern):
-                        document_content += lines[start_line + l]
+            elif section_lines[0].upper() == 'LAST':
+                temp_content = []
+                while start_line < len(lines):
+                    if is_end_pattern(lines, start_line):
+                        break
+                    if is_content_line(lines[start_line], term, header_pattern):
+                        temp_content.append(lines[start_line])
+                    start_line += 1
+                document_content += ''.join(temp_content[-int(section_lines[1]):])
+
+            elif section_lines[0].upper() == 'SPECIFIC':
+                specific_lines = [int(l) for l in section_lines[1].split(",")]
+                for l in specific_lines:
+                    if start_line + l < len(lines) and not is_end_pattern(lines, start_line + l):
+                        if is_content_line(lines[start_line + l], term, header_pattern):
+                            document_content += lines[start_line + l]
 
     return document_content
 

--- a/server/usecases/search_orca_data.py
+++ b/server/usecases/search_orca_data.py
@@ -9,7 +9,7 @@ def preview_document_use_case(data):
     based on the provided data.
     '''
     file_path = data.get('file_path')
-    search_terms = data.get('search_terms')
+    search_terms = data.get('search_terms', [])
     sections = data.get('sections')
     temp_specify_lines = data.get('specify_lines')
     use_total_lines = data.get('use_total_lines', False)
@@ -42,7 +42,7 @@ def find_sections_use_case(data):
     provided search query.
     '''
     file_path = data.get('file_path')
-    search_terms = data.get('search_terms')
+    search_terms = data.get('search_terms', [])
     sections = data.get('sections')
     temp_specify_lines = data.get('specify_lines')
     use_total_lines = data.get('use_total_lines', False)


### PR DESCRIPTION
Fixes #138 

**What was changed?**

I modified the file_search_operations file to support searching for multiple terms in a document. Specifically, I introduced a dictionary term_line_nums to track occurrences of each search term and their respective line numbers. Additionally, in usecases/search_orca_data, I ensured that search_terms is always initialized as a list by adding a default empty list ([]) in data.get('search_terms', []).

**Why was it changed?**

Previously, the system was likely handling only a single search term at a time. By adding support for multiple search terms, I improved the flexibility and usability of the search feature, allowing users to search for multiple keywords in a single request.

**How was it changed?**

1. file_search_operations file
- Added term_line_nums = {term: [] for term in search_terms} to initialize a dictionary that stores line numbers for each term.
- Implemented a loop to iterate through search_terms and track their occurrences in lines.

2. usecases/search_orca_data file
- Changed search_terms = data.get('search_terms') to search_terms = data.get('search_terms', []) to prevent NoneType errors when no terms are provided.

**Screenshots that show the changes (if applicable):**
![image](https://github.com/user-attachments/assets/a3888338-9ea1-433f-bbcc-e3ae4b8f1108)

