### PR TITLE
Fixed issue130 - added API support for multi file upload

### DIFF
--- a/server/application/rest/upload_files.py
+++ b/server/application/rest/upload_files.py
@@ -22,9 +22,6 @@ HTTP_STATUS_CODES_MAPPING = {
 @blueprint.route('/upload', methods=['POST'])
 @cross_origin()
 def file_upload():
-    '''
-    This defines the API endpoint to upload input file
-    '''
     if 'file' not in request.files:
         return Response(
             json.dumps({'message': 'No file part'}),
@@ -33,16 +30,26 @@ def file_upload():
         )
     files = request.files.getlist('file')
     all_responses = []
-    status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
-    for f in files:
-        response = file_upload_use_case(f)
-        if response.response_type != ResponseTypes.SUCCESS:
-            status_code = HTTP_STATUS_CODES_MAPPING[response.response_type]
+    final_status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
+
+    for file in files:
+        response = file_upload_use_case(file)      
+        current_code = HTTP_STATUS_CODES_MAPPING[response.response_type]
+        if current_code != HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]:
+            final_status_code = current_code
+            
         all_responses.append(response.value)
+
+    if len(all_responses) == 1:
+        return Response(
+            json.dumps(all_responses[0]),
+            mimetype="application/json",
+            status=final_status_code,
+        )
     return Response(
         json.dumps({"files": all_responses}),
         mimetype="application/json",
-        status=status_code,
+        status=final_status_code,
     )
 
 @blueprint.route('/api/data', methods=['GET'])

--- a/server/application/rest/upload_files.py
+++ b/server/application/rest/upload_files.py
@@ -31,14 +31,18 @@ def file_upload():
             mimetype="application/json",
             status=HTTP_STATUS_CODES_MAPPING[ResponseTypes.PARAMETER_ERROR],
         )
-
-    file = request.files['file']
-    response = file_upload_use_case(file)
-
+    files = request.files.getlist('file')
+    all_responses = []
+    status_code = HTTP_STATUS_CODES_MAPPING[ResponseTypes.SUCCESS]
+    for f in files:
+        response = file_upload_use_case(f)
+        if response.response_type != ResponseTypes.SUCCESS:
+            status_code = HTTP_STATUS_CODES_MAPPING[response.response_type]
+        all_responses.append(response.value)
     return Response(
-        json.dumps(response.value),
+        json.dumps({"files": all_responses}),
         mimetype="application/json",
-        status=HTTP_STATUS_CODES_MAPPING[response.response_type],
+        status=status_code,
     )
 
 @blueprint.route('/api/data', methods=['GET'])


### PR DESCRIPTION
Fixes #130

**What was changed?**

I updated the /upload endpoint so it can handle multiple file uploads at once. 

**Why was it changed?**

The program needed to support scenarios where users might want to upload more than one file in a single search request. Previously this was not implemented into the API. 

**How was it changed?**

I updated the code in the /upload routine to use request.files.getlist('file') and looped through each file so they could all be uploaded without stopping, even if a file(s) is not valid. The invalid files are not uploaded to the server. 

**Screenshots that show the changes (if applicable):**
<img width="831" alt="Screenshot 2025-02-16 at 1 14 15 PM" src="https://github.com/user-attachments/assets/4f63d586-85a6-4469-81a9-3993a7781b3d" />
<img width="265" alt="Screenshot 2025-02-16 at 1 02 36 PM" src="https://github.com/user-attachments/assets/2738e406-e7a8-4710-a951-8dc71d14101b" />
