### PR TITLE
added multi file preview

### DIFF
--- a/client-app/src/_test_/UploadFile.test.js
+++ b/client-app/src/_test_/UploadFile.test.js
@@ -55,7 +55,7 @@ describe("OrcaDashboardComponent", () => {
 
     // Expect alert to be called due to invalid file type
     await waitFor(() => {
-      expect(window.alert).toHaveBeenCalledWith("Invalid file type. Please upload a .txt file.");
+      expect(window.alert).toHaveBeenCalledWith("Invalid file type: test.pdf");
     });
 
     // Ensure that axios post was never called
@@ -66,12 +66,12 @@ describe("OrcaDashboardComponent", () => {
   /*
   test('Clicking on Preview without uploading any file and validating the error message', async () => {
     render(<OrcaDashboardComponent />);
-  
+
     const previewButton = screen.getByRole('button', { name: /Submit Search Query/i });
-  
+
     // Simulate clicking on Preview button
     fireEvent.click(previewButton);
-  
+
     // Expect alert to be called due to no file selected
     await waitFor(() => {
       expect(window.alert).toHaveBeenCalledWith('Please select a file.');

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -414,7 +414,7 @@ const OrcaDashboardComponent = () => {
                 !searchTerms.length ||
                 !specifyLines.length ||
                 !sections.length ||
-                !selectedFile ||
+                !filePaths.length ||
                 isUploadedFilesEmpty
               }>
               Preview
@@ -429,11 +429,10 @@ const OrcaDashboardComponent = () => {
                 !searchTerms.length ||
                 !specifyLines.length ||
                 !sections.length ||
-                !selectedFile ||
+                !filePaths.length ||
                 isUploadedFilesEmpty
               }>
-              Download{" "}
-               <FaDownload size="1.2em" title="Download Output"/> 
+              Download <FaDownload size="1.2em" title="Download Output" />
             </button>
           </div>
         </div>
@@ -461,21 +460,6 @@ const OrcaDashboardComponent = () => {
               </div>
             </div>
           )}
-
-        <div className="button-container">
-          <button
-            className="btn btn-primary"
-            onClick={fetchDocumentPreview}
-            disabled={
-              !searchTerms.length ||
-              !specifyLines.length ||
-              !sections.length ||
-              !filePaths.length ||
-              isUploadedFilesEmpty
-            }>
-            Preview
-          </button>
-        </div>
 
         {showPreviewModal && (
           <div
@@ -505,7 +489,7 @@ const OrcaDashboardComponent = () => {
                       !filePaths.length ||
                       isUploadedFilesEmpty
                     }>
-                    <FaDownload size="1.2em" title="Download Output"/>
+                    <FaDownload size="1.2em" title="Download Output" />
                   </button>
                   <button className="btn btn-secondary" onClick={() => setShowPreviewModal(false)}>
                     Close
@@ -515,21 +499,6 @@ const OrcaDashboardComponent = () => {
             </div>
           </div>
         )}
-
-        <div className="button-container">
-          <button
-            className="btn btn-primary"
-            onClick={onSubmit}
-            disabled={
-              !searchTerms.length ||
-              !specifyLines.length ||
-              !sections.length ||
-              !filePaths.length ||
-              isUploadedFilesEmpty
-            }>
-            <FaDownload size="1.2em" title="Download Output" />
-          </button>
-        </div>
       </div>
     </div>
   );

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -1,14 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
-import { useEffect } from "react";
 import { saveAs } from "file-saver";
 import { FaDownload } from "react-icons/fa6";
 import "../styles/OrcaDashboardComponent.css";
 import config from "../utils/config";
 
 const OrcaDashboardComponent = () => {
-  const [selectedFile, setSelectedFile] = useState(null);
-  const [filePath, setFilePath] = useState("");
+  const [selectedFile, setSelectedFile] = useState([]);
+  const [filePaths, setFilePaths] = useState([]);
   const [searchTerms, setSearchTerms] = useState([]);
   const [specifyLines, setSpecifyLines] = useState([]);
   const [sections, setSections] = useState([]);
@@ -24,18 +23,19 @@ const OrcaDashboardComponent = () => {
   const [selectedFileName, setSelectedFileName] = useState("No file chosen");
 
   const onFileSelected = (event) => {
-    const selectedFile = event.target.files[0];
-    if (selectedFile.type !== "text/plain") {
-      alert("Invalid file type. Please upload a .txt file.");
-      return;
-    }
-
-    if (uploadedFiles.includes(selectedFile.name)) {
-      alert(`The file "${selectedFile.name}" has already been uploaded.`);
-      return;
-    }
-    setSelectedFile(selectedFile);
-    setSelectedFileName(selectedFile.name);
+    const files = Array.from(event.target.files);
+    const validFiles = files.filter((file) => {
+      if (file.type !== "text/plain") {
+        alert(`Invalid file type: ${file.name}`);
+        return false;
+      }
+      if (uploadedFiles.includes(file.name)) {
+        alert(`The file "${file.name}" has already been uploaded.`);
+        return false;
+      }
+      return true;
+    });
+    setSelectedFile(validFiles);
   };
 
   const isSearchQueryEnabled = () => {
@@ -84,52 +84,59 @@ const OrcaDashboardComponent = () => {
   };
 
   const onUpload = () => {
-    if (!selectedFile) {
-      console.error("No file selected");
+    if (!selectedFile.length) {
+      alert("Please choose a file to upload.");
       return;
     }
 
-    if (uploadedFiles.includes(selectedFile.name)) {
-      alert(`The file "${selectedFile.name}" has already been uploaded.`);
-      return;
-    }
+    selectedFile.forEach((file) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      axios
+        .post(`${config.apiBaseUrl}/upload`, formData)
+        .then((response) => {
+          setUploadedFiles((prev) => [...prev, response.data.file_name]);
+          setFilePaths((prev) => [...prev, response.data.file_path]);
+          setSelectedFileName(file.name);
+        })
+        .catch((error) => console.error("Upload error:", error));
+    });
 
-    const formData = new FormData();
-    formData.append("file", selectedFile);
-
-    axios
-      .post(`${config.apiBaseUrl}/upload`, formData)
-      .then((response) => {
-        const uploadedFileName = response.data.file_name;
-        setFilePath(response.data.file_path);
-        setUploadedFiles((prevUploadedFiles) => [...prevUploadedFiles, uploadedFileName]);
-      })
-      .catch((error) => {
-        console.error("Error uploading file:", error);
-      });
+    setSelectedFile([]);
+    document.getElementById("fileUpload").value = "";
   };
 
-  const removeUploadedFile = (file) => {
+  const removeUploadedFile = (fileName) => {
     setUploadedFiles((prevUploadedFiles) => {
-      const updatedFiles = prevUploadedFiles.filter((f) => f !== file);
-      setSelectedFile(null);
-      setSelectedFileName("No file chosen");
-      const inputElement = document.getElementById("fileInput");
-      if (inputElement) {
-        inputElement.value = "";
-      }
+      const index = prevUploadedFiles.indexOf(fileName);
+      if (index === -1) return prevUploadedFiles;
+
+      const updatedFiles = [...prevUploadedFiles];
+      updatedFiles.splice(index, 1);
+
+      setFilePaths((prevPaths) => {
+        const updatedPaths = [...prevPaths];
+        updatedPaths.splice(index, 1);
+        return updatedPaths;
+      });
+
       return updatedFiles;
     });
+
+    setSelectedFile([]);
+    setSelectedFileName("No file chosen");
+    const inputElement = document.getElementById("fileUpload");
+    if (inputElement) inputElement.value = "";
   };
 
   const onSubmit = () => {
-    if (!selectedFile) {
+    if (!filePaths.length) {
       alert("Please select a file.");
       return;
     }
 
     const data = {
-      file_path: filePath.toString(),
+      file_paths: filePaths,
       search_terms: searchTerms,
       sections: sections,
       specify_lines: formatSpecifyLines(),
@@ -156,7 +163,7 @@ const OrcaDashboardComponent = () => {
 
   const onSearchQuerySubmit = () => {
     setShowCard(false);
-    if (!selectedFile) {
+    if (!filePaths.length) {
       alert("Please select a file.");
       return;
     } else {
@@ -247,13 +254,13 @@ const OrcaDashboardComponent = () => {
   };
 
   const fetchDocumentPreview = () => {
-    if (!selectedFile) {
+    if (!filePaths.length) {
       alert("Please select a file.");
       return;
     }
 
     const data = {
-      file_path: filePath.toString(),
+      file_paths: filePaths,
       search_terms: searchTerms,
       sections: sections,
       specify_lines: formatSpecifyLines(),
@@ -300,6 +307,7 @@ const OrcaDashboardComponent = () => {
               id="fileUpload"
               onChange={onFileSelected}
               accept=".txt"
+              multiple
               aria-label="Upload ORCA data file"
             />
             <button className="btn btn-primary" onClick={onUpload}>
@@ -429,7 +437,7 @@ const OrcaDashboardComponent = () => {
               !searchTerms.length ||
               !specifyLines.length ||
               !sections.length ||
-              !selectedFile ||
+              !filePaths.length ||
               isUploadedFilesEmpty
             }>
             Preview
@@ -460,7 +468,7 @@ const OrcaDashboardComponent = () => {
                       !searchTerms.length ||
                       !specifyLines.length ||
                       !sections.length ||
-                      !selectedFile ||
+                      !filePaths.length ||
                       isUploadedFilesEmpty
                     }>
                     <FaDownload size="1.2em" title="Download Output" />
@@ -482,7 +490,7 @@ const OrcaDashboardComponent = () => {
               !searchTerms.length ||
               !specifyLines.length ||
               !sections.length ||
-              !selectedFile ||
+              !filePaths.length ||
               isUploadedFilesEmpty
             }>
             <FaDownload size="1.2em" title="Download Output" />

--- a/server/tests/app_test.py
+++ b/server/tests/app_test.py
@@ -87,7 +87,7 @@ class TestAPI(unittest.TestCase):
         mock_extract.return_value = 'Extracted content'
 
         data = {
-            'file_path': 'test.txt',
+            'file_paths': ['test.txt'],  
             'search_terms': ['test'],
             'sections': [1],
             'specify_lines': '10'
@@ -100,11 +100,11 @@ class TestAPI(unittest.TestCase):
             response = preview_document_use_case(data)
 
         self.assertIsInstance(response, ResponseSuccess)
-        self.assertEqual(response.value, {'document_content': 'Extracted content'})
+        self.assertEqual(response.value, {'document_content': "\n===== File name: test.txt =====\nExtracted content\n"})
 
         mock_extract.assert_called_once()
         call_args = mock_extract.call_args[0]
-        self.assertEqual(call_args[1:], (['test'], [1], ['10'], False, 2000))
+        self.assertEqual(call_args, ('test.txt', ['test'], [1], ['10'], False, 2000))
 
 
 if __name__ == '__main__':

--- a/server/usecases/search_orca_data.py
+++ b/server/usecases/search_orca_data.py
@@ -1,6 +1,7 @@
 from responses import ResponseSuccess, ResponseFailure, ResponseTypes
 from docx import Document
 from services.file_search_operations import extract_sections, save_document_to_bytes
+import os
 
 
 def preview_document_use_case(data):
@@ -8,26 +9,35 @@ def preview_document_use_case(data):
     Prepares and returns a preview of the document content 
     based on the provided data.
     '''
-    file_path = data.get('file_path')
+    file_paths = data.get('file_paths')
     search_terms = data.get('search_terms', [])
     sections = data.get('sections')
     temp_specify_lines = data.get('specify_lines')
     use_total_lines = data.get('use_total_lines', False)
     total_lines = data.get('total_lines', 2000)
 
-    if not all([file_path, search_terms, sections, temp_specify_lines]):
+    if not all([file_paths, search_terms, sections, temp_specify_lines]):
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, 'Missing required fields')
 
     try:
         sections = list(map(int, sections))
         specify_lines = [temp_specify_lines] * len(sections)
-        document_content = extract_sections(file_path, search_terms, sections, 
-                                            specify_lines, use_total_lines, total_lines)
-        
-        if not document_content:
+
+        combined_content = ""
+        has_content = False
+        for file_path in file_paths:
+            file_name = os.path.basename(file_path)
+            document_content = extract_sections(file_path, search_terms, sections,
+                                        specify_lines, use_total_lines, total_lines)
+            if document_content:
+                has_content = True
+                combined_content += f"\n===== File name: {file_name} =====\n{document_content}\n"
+
+        if not has_content:
             return ResponseFailure(ResponseTypes.NOT_FOUND, 'No data found for the provided search term.')
 
-        return ResponseSuccess({'document_content': document_content})
+        return ResponseSuccess({'document_content': combined_content})
+    
     except FileNotFoundError as e:
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, f'File not found: {str(e)}')
     except PermissionError as e:
@@ -41,29 +51,37 @@ def find_sections_use_case(data):
     Finds and returns a document with the specified data based on the 
     provided search query.
     '''
-    file_path = data.get('file_path')
+    file_paths = data.get('file_paths')
     search_terms = data.get('search_terms', [])
     sections = data.get('sections')
     temp_specify_lines = data.get('specify_lines')
     use_total_lines = data.get('use_total_lines', False)
     total_lines = data.get('total_lines', 2000)
 
-    if not all([file_path, search_terms, sections, temp_specify_lines]):
+    if not all([file_paths, search_terms, sections, temp_specify_lines]):
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, 'Missing required fields')
 
-    sections = list(map(int, sections))
-    specify_lines = [temp_specify_lines] * len(sections)
-
     try:
-        document_content = extract_sections(file_path, search_terms, sections, 
-                                            specify_lines, use_total_lines, total_lines)
-        
-        if not document_content:
-            return ResponseFailure(ResponseTypes.NOT_FOUND, 'No data found for the provided search term.')
+        sections = list(map(int, sections))
+        specify_lines = [temp_specify_lines] * len(sections)
 
         document = Document()
-        for paragraph in document_content.split('\n'):
-            document.add_paragraph(paragraph.strip())
+        has_content = False
+        for file_path in file_paths:
+            file_name = os.path.basename(file_path)
+            document_content = extract_sections(
+                file_path, search_terms, sections,
+                specify_lines, use_total_lines, total_lines
+            )
+
+            if document_content:
+                has_content = True
+                document.add_paragraph(f"===== File: {file_name} =====").bold = True
+                for paragraph in document_content.strip().split('\n'):
+                    document.add_paragraph(paragraph.strip())
+        
+        if not has_content:
+            return ResponseFailure(ResponseTypes.NOT_FOUND, 'No data found for the provided search term.')     
         docx_bytes = save_document_to_bytes(document)
         return ResponseSuccess(docx_bytes)
     except FileNotFoundError as e:


### PR DESCRIPTION
Fixes #137 

**What was changed?**

**Frontend (⁠ OrcaDashboardComponent.jsx ⁠):**
  - Migrated from handling a single file upload to supporting *multiple file uploads*.
  - Replaced ⁠ filePath ⁠ with ⁠ filePaths ⁠ (array of uploaded file paths).
  - Updated logic in ⁠ onUpload ⁠, ⁠ removeUploadedFile ⁠, ⁠ onSubmit ⁠, and ⁠ fetchDocumentPreview ⁠ to handle *arrays* instead of single values.

**Backend (⁠ preview_document_use_case ⁠ & ⁠ find_sections_use_case ⁠):**
  - Changed request input from ⁠ file_path ⁠ (single string) to ⁠ file_paths ⁠ (list of file paths).
  - Iterated through all file paths to extract and merge document content.
  - Added ⁠ has_content ⁠ validation to return a proper ⁠ 404 ⁠ if no matches are found across files.


**Why was it changed?**

- ⁠  ⁠The previous implementation only supported a *single file* for both preview and download.
-   ⁠Removing or re-uploading files after previewing led to *stale state* and inaccurate document results.
- ⁠  ⁠To support the real-world use case of searching across multiple ORCA files and aggregating data into a single preview or DOCX.


**How was it changed?**
**Frontend:**

-   ⁠selectedFile ⁠ changed from single file to list (⁠ useState([]) ⁠).
-   ⁠In ⁠ onUpload ⁠, used ⁠ selectedFile.forEach(...) ⁠ to handle each file upload individually.
-   ⁠*State management* of ⁠ filePaths ⁠ and ⁠ uploadedFiles ⁠ was synchronized using indexes (so file and path pairs match).
-   ⁠⁠ removeUploadedFile ⁠ now properly updates both ⁠ uploadedFiles ⁠ and ⁠ filePaths ⁠ arrays to prevent desync.
-   ⁠In ⁠ onSubmit ⁠ and ⁠ fetchDocumentPreview ⁠, sent ⁠ file_paths ⁠ instead of ⁠ file_path ⁠ in request payload.

**Backend:**
•⁠  ⁠⁠ preview_document_use_case() ⁠ and ⁠ find_sections_use_case() ⁠ now:
  - Accept ⁠ file_paths ⁠ as input.
  - Loop through each file to extract content.
  - Append file name headers in both preview and DOCX output.
  - Return ⁠ 404 ⁠ with message if no file has matching content (⁠ has_content = False ⁠ guard added).

**Screenshots that show the changes (if applicable):**
