### PR TITLE
Fixed issue 164

### DIFF
--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -39,7 +39,10 @@ const OrcaDashboardComponent = () => {
   };
 
   const isSearchQueryEnabled = () => {
-    return !isUploadedFilesEmpty && searchTerms.length && specifyLines.length && sections.length;
+    const line = specifyLines[0] || {};
+    const lineNumberRequired = line.value === "FIRST" || line.value === "LAST";
+    const isLineNumberMissing = lineNumberRequired && (!line.lineNumber || line.lineNumber.trim() === "");
+    return !isUploadedFilesEmpty && searchTerms.length && specifyLines.length && sections.length && !isLineNumberMissing;
   };
 
   const handleSpecifyLineChange = (value) => {
@@ -247,12 +250,16 @@ const OrcaDashboardComponent = () => {
     setSameCriteria(false);
   };
 
+  const line = specifyLines[0] || {};
+  const lineNumberRequired = line.value === "FIRST" || line.value === "LAST";
+  const isLineNumberMissing = lineNumberRequired && (!line.lineNumber || line.lineNumber.trim() === "");
   const isDisabled =
     !searchTerms.length ||
     !specifyLines.length ||
     !sections.length ||
     !selectedFile ||
-    isUploadedFilesEmpty;
+    isUploadedFilesEmpty ||
+    isLineNumberMissing;
 
   const fetchDocumentPreview = () => {
     if (!filePaths.length) {


### PR DESCRIPTION
Fixes #164 

**What was changed?**

This change applies to the OrcaDashboardComponent.js file in the React front end. Specifically, it modifies how the “Submit Search Query,” “Preview,” and “Download” buttons are enabled or disabled.

**Why was it changed?**

Users were able to enable the buttons after choosing “FIRST” or “LAST” in the “Enter how you want the lines specified” dropdown, even if they did not provide a line number. This caused confusion and errors when attempting to preview or download without a valid line number.

**How was it changed?**

- Added a simple check in the existing isSearchQueryEnabled() function and the isDisabled constant to verify whether the user has provided a line number when “FIRST” or “LAST” is selected.
- If the user does not supply a line number, the buttons remain disabled.

**Screenshots that show the changes (if applicable):**
![image](https://github.com/user-attachments/assets/09a3b3c1-7377-4f92-afee-0821b86647fc)

