### PR TITLE
Gaussian Extranction UI Updates - Issue #163

### DIFF
--- a/client-app/src/components/GaussianDashboardComponent.js
+++ b/client-app/src/components/GaussianDashboardComponent.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import axios from "axios";
 import { saveAs } from "file-saver";
+import { FaDownload } from "react-icons/fa6";
 import "../styles/OrcaDashboardComponentLegacy.css";
 import config from "../utils/config";
 
@@ -113,9 +114,16 @@ const GaussianDashboardComponent = () => {
       <div className="text-center">
         <h2 className="mb-4">Extract data from Gaussian files to Word documents</h2>
         <div className="mb-3 text-start">
-          <span>Upload your Gaussian data file</span>
+          <label htmlFor="fileUpload" className="mb-2">
+            Upload your Gaussian data file
+          </label>
           <div className="input-group">
-            <input type="file" className="form-control" onChange={onFileSelected} accept=".log" />
+            <input
+            type="file"
+            id="fileUpload"
+            className="form-control"
+            onChange={onFileSelected}
+            accept=".log" />
             <button className="btn btn-primary" onClick={onUpload}>
               Upload
             </button>
@@ -123,10 +131,11 @@ const GaussianDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Enter the terms you wish to search for (txt only):</span>
+          <label htmlFor="searchTermInput" className="mb-2">Enter the terms you wish to search for (txt only):</label>
           <input
             type="text"
             className="form-control"
+            id="searchTermInput"
             placeholder="E.g., CARTESIAN COORDINATES"
             value={searchTerms}
             onChange={(e) => setSearchTerms(e.target.value.toUpperCase())}
@@ -134,10 +143,11 @@ const GaussianDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Enter how you want the lines specified:</span>
+          <label htmlFor="specifyLinesInput" className="mb-2">Enter how you want the lines specified:</label>
           <input
             type="text"
             className="form-control"
+            id="specifyLinesInput"
             placeholder="E.g., WHOLE, FIRST X, LAST X"
             value={specifyLines}
             onChange={(e) => setSpecifyLines(e.target.value.toUpperCase())}
@@ -145,10 +155,11 @@ const GaussianDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Number of sections?</span>
+          <label htmlFor="numSectionsInput" className="mb-2">Number of sections?</label>
           <input
             type="text"
             className="form-control"
+            id="numSectionsInput"
             placeholder="Input as number..."
             value={sections}
             onChange={(e) => setSections(e.target.value)}
@@ -156,10 +167,11 @@ const GaussianDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Use total lines?</span>
+          <label htmlFor="useTotalLinesInput" className="mb-2">Use total lines?</label>
           <input
             type="text"
             className="form-control"
+            id="useTotalLinesInput"
             placeholder="TRUE/FALSE"
             value={useTotalLines}
             onChange={(e) => setUseTotalLines(e.target.value.toUpperCase())}
@@ -167,10 +179,11 @@ const GaussianDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
-          <span>Total number of lines for output doc?</span>
+          <label htmlFor="numLinesInput" className="mb-2">Total number of lines for output doc?</label>
           <input
             type="text"
             className="form-control"
+            id="numLinesInput"
             placeholder="Input as number..."
             value={totalLines}
             onChange={(e) => {
@@ -179,14 +192,15 @@ const GaussianDashboardComponent = () => {
             }}
           />
         </div>
-        <button className="btn btn-primary" onClick={fetchDocumentPreview}>
-          Preview Output
-        </button>
-        <div className="buttonSpacing">
+        <div className="button-group">
+          <button className="btn btn-primary" onClick={fetchDocumentPreview}>
+            Preview
+          </button>
           <button className="btn btn-primary" onClick={onSubmit}>
-            Download Output
+            Download <FaDownload size="1.2em"/>
           </button>
         </div>
+
 
         {previewContent && (
           <div className="document-preview">

--- a/client-app/src/components/GaussianDashboardComponent.js
+++ b/client-app/src/components/GaussianDashboardComponent.js
@@ -131,6 +131,10 @@ const GaussianDashboardComponent = () => {
         </div>
 
         <div className="mb-3 text-start">
+          <label>Uploaded Files:</label>
+        </div>
+
+        <div className="mb-3 text-start">
           <label htmlFor="searchTermInput" className="mb-2">Enter the terms you wish to search for (txt only):</label>
           <input
             type="text"
@@ -140,29 +144,35 @@ const GaussianDashboardComponent = () => {
             value={searchTerms}
             onChange={(e) => setSearchTerms(e.target.value.toUpperCase())}
           />
+          <div className="mt-3">
+            <span>Search Terms:</span>
+          </div>
+          <div className="form-check mt-2">
+              <input
+                className="form-check-input"
+                type="checkbox"
+              />
+              <label className="form-check-label" htmlFor="sameCriteriaCheckbox">
+                Is the search criteria same for all search terms
+              </label>
+            </div>
+        </div>
+  
+        <div className="mb-3 text-start">
+          <label htmlFor="specifyLinesSelect" className="mb-2">
+            Enter how you want the lines specified:
+          </label>
         </div>
 
         <div className="mb-3 text-start">
-          <label htmlFor="specifyLinesInput" className="mb-2">Enter how you want the lines specified:</label>
-          <input
-            type="text"
-            className="form-control"
-            id="specifyLinesInput"
-            placeholder="E.g., WHOLE, FIRST X, LAST X"
-            value={specifyLines}
-            onChange={(e) => setSpecifyLines(e.target.value.toUpperCase())}
-          />
-        </div>
-
-        <div className="mb-3 text-start">
-          <label htmlFor="numSectionsInput" className="mb-2">Number of sections?</label>
+          <label htmlFor="numSectionsInput" className="mb-2">
+            Number of sections?
+          </label>
           <input
             type="text"
             className="form-control"
             id="numSectionsInput"
-            placeholder="Input as number..."
-            value={sections}
-            onChange={(e) => setSections(e.target.value)}
+            placeholder="ex: 1-5 or 1,2,5"
           />
         </div>
 
@@ -193,6 +203,9 @@ const GaussianDashboardComponent = () => {
           />
         </div>
         <div className="button-group">
+          <button className="btn btn-primary" title="Submit Search Query">
+            Submit Search Query
+          </button>
           <button className="btn btn-primary" onClick={fetchDocumentPreview}>
             Preview
           </button>

--- a/client-app/src/styles/OrcaDashboardComponentLegacy.css
+++ b/client-app/src/styles/OrcaDashboardComponentLegacy.css
@@ -37,8 +37,11 @@ span {
   word-wrap: break-word;
 }
 
-.buttonSpacing {
-  padding: 10px;
+.button-group {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 10px;
 }
 
 /* :host ::ng-deep .custom-ms 


### PR DESCRIPTION
Fixes #163 

**What was changed?**

Gaussian Log Extraction page was updated to have similar styling to ORCA equivalent page.

**Why was it changed?**

Current Gaussian page had elements too close together, causing for a cluttered UI feel, along with having styling that was inconsistent with our current and update4d ORCA page.

**How was it changed?**

Bottom margins were added under Input Label fields for the Gaussian File Page, download and preview buttons were aligned horizontally, in addition to the adding of the download icon. 

**Screenshots that show the changes (if applicable):**

![image](https://github.com/user-attachments/assets/a46243f3-5e3a-4f9a-b82d-771b8e628d9a)
