### PR TITLE
added preview panel

### DIFF
--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -21,6 +21,7 @@ const OrcaDashboardComponent = () => {
   const [previewContent, setPreviewContent] = useState("");
   const [showPreviewModal, setShowPreviewModal] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState("No file chosen");
+  const [showPreview, setShowPreview] = useState(false);
 
   const onFileSelected = (event) => {
     const files = Array.from(event.target.files);
@@ -111,16 +112,15 @@ const OrcaDashboardComponent = () => {
       const updatedFiles = prevUploadedFiles.filter((f) => f !== file);
       if (selectedFile && selectedFile.name === file) {
         setSelectedFile(null);
-        setSelectedFileName("File Upload"); 
+        setSelectedFileName("File Upload");
         const inputElement = document.getElementById("fileUpload");
         if (inputElement) {
-          inputElement.value = ""; 
+          inputElement.value = "";
         }
       }
       return updatedFiles;
     });
   };
-  
 
   const onSubmit = () => {
     if (!filePaths.length) {
@@ -169,19 +169,18 @@ const OrcaDashboardComponent = () => {
     const truncated = fileName.substring(0, maxLength - 3);
     return `${truncated}...`;
   };
-  
+
   const downloadDocument = (blob) => {
     const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
     const baseFileName = selectedFileName.replace(/\.[^/.]+$/, "");
     const searchTerm = searchTerms.join("_").slice(0, 50);
-  
-  
+
     let fileName = `${date}_${baseFileName}_${searchTerm}.docx`;
     fileName = truncateName(fileName, 100);
-  
+
     saveAs(blob, fileName);
   };
-  
+
   const handleKeyPress = (e, setterFunc) => {
     if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
       e.preventDefault();
@@ -271,7 +270,7 @@ const OrcaDashboardComponent = () => {
       .post(`${config.apiBaseUrl}/preview`, data)
       .then((response) => {
         setPreviewContent(response.data.document_content);
-        setShowPreviewModal(true);
+        setShowPreview(true);
       })
       .catch((error) => {
         if (error.response && error.response.status === 404) {
@@ -294,204 +293,210 @@ const OrcaDashboardComponent = () => {
   }, []);
 
   return (
-    <div className="container py-5 d-flex justify-content-center">
-      <div className="text-center">
-        <h2 className="mb-4">Extract data from ORCA files to Word documents</h2>
-        <div className="mb-3 text-start">
-          <label htmlFor="fileUpload" className="mb-2">
-            Upload your ORCA data file:
-          </label>
-          <div className="input-group">
-            <input
-              className="form-control"
-              type="file"
-              id="fileUpload"
-              onChange={onFileSelected}
-              accept=".txt"
-              multiple
-              aria-label="Upload ORCA data file"
-            />
-            <button className="btn btn-primary" onClick={onUpload}>
-              Upload
-            </button>
+    <div className="container py-5">
+      <h2 className="mb-4 text-center">Extract data from ORCA files to Word documents</h2>
+      <div className="row justify-content-center">
+        <div className={`col-md-${showPreview ? "6" : "8"}`}>
+          {" "}
+          <div className="mb-3 text-start">
+            <label htmlFor="fileUpload" className="mb-2">
+              Upload your ORCA data file:
+            </label>
+            <div className="input-group">
+              <input
+                className="form-control"
+                type="file"
+                id="fileUpload"
+                onChange={onFileSelected}
+                accept=".txt"
+                multiple
+                aria-label="Upload ORCA data file"
+              />
+              <button className="btn btn-primary" onClick={onUpload}>
+                Upload
+              </button>
+            </div>
           </div>
-        </div>
-
-        <div className="mb-3 text-start">
-          <label>Uploaded Files:</label>
-          {uploadedFiles.map((file, index) => (
-            <span key={index} className="badge bg-secondary ms-1 me-1 mb-2">
-              {truncateName(file, 40)}
-              <button
-                type="button"
-                className="btn-close ms-1"
-                aria-label="Remove"
-                onClick={() => removeUploadedFile(file)}></button>
-            </span>
-          ))}
-        </div>
-
-        <div className="mb-3 text-start">
-          <label htmlFor="searchTermInput" className="mb-2">
-            Enter the terms you wish to search for (txt only):
-          </label>
-          <div>
+          <div className="mb-3 text-start">
+            <label>Uploaded Files:</label>
+            {uploadedFiles.map((file, index) => (
+              <span key={index} className="badge bg-secondary ms-1 me-1 mb-2">
+                {truncateName(file, 40)}
+                <button
+                  type="button"
+                  className="btn-close ms-1"
+                  aria-label="Remove"
+                  onClick={() => removeUploadedFile(file)}></button>
+              </span>
+            ))}
+          </div>
+          <div className="mb-3 text-start">
+            <label htmlFor="searchTermInput" className="mb-2">
+              Enter the terms you wish to search for (txt only):
+            </label>
+            <div>
+              <input
+                type="text"
+                className="form-control"
+                id="searchTermInput"
+                placeholder="E.g., CARTESIAN COORDINATES"
+                onKeyPress={(e) => handleKeyPress(e, setSearchTerms)}
+                onBlur={(e) => handleSearchTermBlur(e, setSearchTerms)}
+              />
+              <div className="mt-3">
+                <span>Search Terms:</span>
+                {searchTerms.map((term, index) => (
+                  <span
+                    key={index}
+                    className="badge bg-secondary ms-1 me-1 mb-2"
+                    onClick={() => removeTag(index, setSearchTerms)}>
+                    {truncateName(term, 40)}
+                    <button type="button" className="btn-close ms-1" aria-label="Remove"></button>
+                  </span>
+                ))}
+              </div>
+            </div>
+            {searchTerms.length > 1 && (
+              <div className="form-check mt-2">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  id="sameCriteriaCheckbox"
+                  checked={sameCriteria}
+                  onChange={handleSameCriteriaChange}
+                />
+                <label className="form-check-label" htmlFor="sameCriteriaCheckbox">
+                  Is the search criteria same for all search terms
+                </label>
+              </div>
+            )}
+          </div>
+          <div className="mb-3 text-start">
+            <label htmlFor="specifyLinesSelect" className="mb-2">
+              Enter how you want the lines specified:
+            </label>
+            {renderSpecifyLine()}
+          </div>
+          <div className="mb-3 text-start">
+            <label htmlFor="numSectionsInput" className="mb-2">
+              Number of sections?
+            </label>
             <input
               type="text"
               className="form-control"
-              id="searchTermInput"
-              placeholder="E.g., CARTESIAN COORDINATES"
-              onKeyPress={(e) => handleKeyPress(e, setSearchTerms)}
-              onBlur={(e) => handleSearchTermBlur(e, setSearchTerms)}
+              id="numSectionsInput"
+              placeholder="ex: 1-5 or 1,2,5"
+              defaultValue={sections.join(", ")}
+              onBlur={handleNumSectionsBlur}
             />
-            <div className="mt-3">
-            <span>Search Terms:</span>
-              {searchTerms.map((term, index) => (
-                <span
-                  key={index}
-                  className="badge bg-secondary ms-1 me-1 mb-2"
-                  onClick={() => removeTag(index, setSearchTerms)}>
-                  {truncateName(term, 40)}
-                  <button type="button" className="btn-close ms-1" aria-label="Remove"></button>
-                </span>
-            ))}
+          </div>
+          <div className="button-group">
+            <div className="button-container" title="Please fill all required fields">
+              <button
+                className="btn btn-primary"
+                onClick={() => onSearchQuerySubmit()}
+                disabled={
+                  !isSearchQueryEnabled() ||
+                  isUploadedFilesEmpty ||
+                  isSearchTermsEmpty ||
+                  isSpecifyLinesEmpty ||
+                  isSectionsEmpty
+                }
+                title="Submit Search Query">
+                Submit Search Query
+              </button>
+            </div>
+            <div className="button-container" title="Please fill all required fields">
+              <button
+                className="btn btn-primary"
+                onClick={fetchDocumentPreview}
+                disabled={isDisabled}
+                title="Preview Output">
+                Preview
+              </button>
+            </div>
+            <div className="button-container" title="Please fill all required fields">
+              <button
+                className="btn btn-primary"
+                title="Download Output"
+                onClick={onSubmit}
+                disabled={isDisabled}>
+                Download <FaDownload size="1.2em" />
+              </button>
             </div>
           </div>
-          {searchTerms.length > 1 && (
-            <div className="form-check mt-2">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="sameCriteriaCheckbox"
-                checked={sameCriteria}
-                onChange={handleSameCriteriaChange}
-              />
-              <label className="form-check-label" htmlFor="sameCriteriaCheckbox">
-                Is the search criteria same for all search terms
-              </label>
-            </div>
-          )}
-        </div>
-
-        <div className="mb-3 text-start">
-          <label htmlFor="specifyLinesSelect" className="mb-2">
-            Enter how you want the lines specified:
-          </label>
-          {renderSpecifyLine()}
-        </div>
-
-        <div className="mb-3 text-start">
-          <label htmlFor="numSectionsInput" className="mb-2">
-            Number of sections?
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="numSectionsInput"
-            placeholder="ex: 1-5 or 1,2,5"
-            defaultValue={sections.join(", ")}
-            onBlur={handleNumSectionsBlur}
-          />
-        </div>
-
-        <div className="button-group">
-          <div className="button-container" title="Please fill all required fields">
-            <button
-              className="btn btn-primary"
-              onClick={() => onSearchQuerySubmit()}
-              disabled={
-                !isSearchQueryEnabled() ||
-                isUploadedFilesEmpty ||
-                isSearchTermsEmpty ||
-                isSpecifyLinesEmpty ||
-                isSectionsEmpty
-              }
-              title="Submit Search Query"
-              >
-              Submit Search Query
-            </button>
-          </div>
-
-          <div className="button-container" title="Please fill all required fields">
-            <button
-              className="btn btn-primary"
-              onClick={fetchDocumentPreview}
-              disabled={isDisabled}
-              title={"Preview Output"}>
-              Preview
-            </button>
-          </div>
-
-          <div className="button-container" title="Please fill all required fields">
-            <button
-              className="btn btn-primary"
-              title={"Download Output"}
-              onClick={onSubmit}
-              disabled={isDisabled}
-              >
-              Download <FaDownload size="1.2em"/>
-            </button>
-          </div>
-        </div>
-
-        {!isUploadedFilesEmpty &&
-          !isSearchTermsEmpty &&
-          !isSpecifyLinesEmpty &&
-          !isSectionsEmpty &&
-          showCard && (
-            <div className="card mt-3">
-              <div className="card-body">
-                <h5 className="card-title">Search Query</h5>
-                <p className="card-text">Search Terms: {searchTerms.join(", ")}</p>
-                <p className="card-text">
-                  Specify Lines: {specifyLines[0].value !== "SELECT" && specifyLines[0].value}
-                  {specifyLines[0].lineNumber ? `, ${specifyLines[0].lineNumber}` : ""}
-                </p>
-                <p className="card-text">Sections: {sections.join(", ")}</p>
-                <div className="d-flex justify-content-end">
-                  <button className="btn btn-primary me-2">Edit</button>
-                  <button className="btn btn-danger" onClick={handleDelete}>
-                    Delete
-                  </button>
+          {!isUploadedFilesEmpty &&
+            !isSearchTermsEmpty &&
+            !isSpecifyLinesEmpty &&
+            !isSectionsEmpty &&
+            showCard && (
+              <div className="card mt-3">
+                <div className="card-body">
+                  <h5 className="card-title">Search Query</h5>
+                  <p className="card-text">Search Terms: {searchTerms.join(", ")}</p>
+                  <p className="card-text">
+                    Specify Lines: {specifyLines[0].value !== "SELECT" && specifyLines[0].value}
+                    {specifyLines[0].lineNumber ? `, ${specifyLines[0].lineNumber}` : ""}
+                  </p>
+                  <p className="card-text">Sections: {sections.join(", ")}</p>
+                  <div className="d-flex justify-content-end">
+                    <button className="btn btn-primary me-2">Edit</button>
+                    <button className="btn btn-danger" onClick={handleDelete}>
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          {showPreviewModal && (
+            <div
+              className="modal"
+              style={{ display: "block", backgroundColor: "rgba(0, 0, 0, 0.5)" }}>
+              <div className="modal-dialog" style={{ maxWidth: "80vw" }}>
+                <div className="modal-content">
+                  <div className="modal-header">
+                    <h5 className="modal-title">Document Preview</h5>
+                    <button
+                      type="button"
+                      className="btn-close"
+                      aria-label="Close"
+                      onClick={() => setShowPreviewModal(false)}></button>
+                  </div>
+                  <div className="modal-body">
+                    <pre>{previewContent}</pre>
+                  </div>
+                  <div className="modal-footer">
+                    <button
+                      className="btn btn-primary"
+                      title={
+                        isDisabled
+                          ? "Please fill all required fields before submitting"
+                          : "Download Output"
+                      }
+                      onClick={onSubmit}
+                      disabled={isDisabled}>
+                      <FaDownload size="1.2em" />
+                    </button>
+                    <button
+                      className="btn btn-secondary"
+                      onClick={() => setShowPreviewModal(false)}>
+                      Close
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
           )}
-
-        {showPreviewModal && (
-          <div
-            className="modal"
-            style={{ display: "block", backgroundColor: "rgba(0, 0, 0, 0.5)" }}>
-            <div className="modal-dialog" style={{ maxWidth: "80vw" }}>
-              <div className="modal-content">
-                <div className="modal-header">
-                  <h5 className="modal-title">Document Preview</h5>
-                  <button
-                    type="button"
-                    className="btn-close"
-                    aria-label="Close"
-                    onClick={() => setShowPreviewModal(false)}></button>
-                </div>
-                <div className="modal-body">
-                  <pre>{previewContent}</pre>
-                </div>
-                <div className="modal-footer">
-                  <button
-                    className="btn btn-primary"
-                    title={isDisabled ? "Please fill all required fields before submitting" : "Download Output"}
-                    onClick={onSubmit}
-                    disabled={isDisabled}
-                    >
-                    <FaDownload
-                    size="1.2em"
-                    />
-                  </button>
-                  <button className="btn btn-secondary" onClick={() => setShowPreviewModal(false)}>
-                    Close
-                  </button>
-                </div>
-              </div>
+        </div>
+        {showPreview && (
+          <div className="col-md-6">
+            <div className="d-flex justify-content-between align-items-center mb-2">
+              <h5>Preview</h5>
+              <button className="btn btn-sm btn-danger" onClick={() => setShowPreview(false)}>
+                Close
+              </button>
             </div>
+            <pre style={{ maxHeight: "400px", overflowY: "auto" }}>{previewContent}</pre>
           </div>
         )}
       </div>


### PR DESCRIPTION
Fixes #165 

**What was changed?**

The OrcaDashboardComponent was modified to conditionally display the preview section alongside the form. The preview content now appears on the right only after clicking the Preview button, and can be closed using a close button to re-center the form.

**Why was it changed?**

Previously, clicking the Preview button would open the preview content in a new window, which was not an ideal user experience. To provide a more seamless and integrated view, the preview section was modified to appear on the right side of the same page, while the ORCA Log Extraction form shifts to the left. This change enhances usability by keeping everything within a single view and avoiding context switching for the user.

**How was it changed?**

Changes were made in OrcaDashboardComponent.js. A new state variable showPreview was added to control the visibility of the preview section. The layout was updated using conditional rendering and Bootstrap grid classes to dynamically adjust column widths based on showPreview. The setShowPreview(true) was added when fetching the preview, and a close button was introduced to set showPreview(false) to hide the preview and re-center the form.

**Screenshots that show the changes (if applicable):**
![image](https://github.com/user-attachments/assets/4dbd2702-1e3f-42b6-aa51-7292f40ba587)
