### PR TITLE
Fixed issue 161 - Gaussian Upload File Feature

### DIFF
--- a/client-app/src/components/GaussianDashboardComponent.js
+++ b/client-app/src/components/GaussianDashboardComponent.js
@@ -5,8 +5,11 @@ import "../styles/OrcaDashboardComponentLegacy.css";
 import config from "../utils/config";
 
 const GaussianDashboardComponent = () => {
-  const [selectedFile, setSelectedFile] = useState(null);
-  const [fileName, setFileName] = useState("");
+  const [selectedFile, setSelectedFile] = useState([]);
+  const [filePaths, setFilePaths] = useState([]);
+  const [uploadedFiles, setUploadedFiles] = useState([]);
+  const [selectedFileName, setSelectedFileName] = useState("No file chosen");
+
   const [searchTerms, setSearchTerms] = useState("");
   const [specifyLines, setSpecifyLines] = useState("");
   const [sections, setSections] = useState("");
@@ -15,37 +18,73 @@ const GaussianDashboardComponent = () => {
   const [previewContent, setPreviewContent] = useState("");
 
   const onFileSelected = (event) => {
-    setSelectedFile(event.target.files[0]);
+    const files = Array.from(event.target.files);
+    const validFiles = files.filter((file) => {
+      if (!file.name.toLowerCase().endsWith(".log")) {
+        alert(`Invalid file type: ${file.name}. Only .log files are allowed for Gaussian.`);
+        return false;
+      }
+      if (uploadedFiles.includes(file.name)) {
+        alert(`The file "${file.name}" has already been uploaded.`);
+        return false;
+      }
+      return true;
+    });
+    setSelectedFile(validFiles);
   };
 
   const onUpload = () => {
-    if (!selectedFile) {
-      console.error("No file selected");
+    if (!selectedFile.length) {
+      alert("Please choose a file to upload.");
       return;
     }
 
-    const formData = new FormData();
-    formData.append("file", selectedFile);
+    selectedFile.forEach((file) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      axios
+        .post(`${config.apiBaseUrl}/upload`, formData)
+        .then((response) => {
+          setUploadedFiles((prev) => [...prev, response.data.file_name]);
+          setFilePaths((prev) => [...prev, response.data.file_path]);
+          setSelectedFileName(file.name);
+        })
+        .catch((error) => console.error("Upload error:", error));
+    });
 
-    axios
-      .post(`${config.apiBaseUrl}/upload`, formData)
-      .then((response) => {
-        console.log("File uploaded successfully:", response);
-        setFileName(response.data.filename);
-      })
-      .catch((error) => {
-        console.error("Error uploading file:", error);
-      });
+    setSelectedFile([]);
+    document.getElementById("fileUpload").value = "";
+  };
+
+  const removeUploadedFile = (file) => {
+    setUploadedFiles((prevUploadedFiles) => {
+      const updatedFiles = prevUploadedFiles.filter((f) => f !== file);
+      if (selectedFile && selectedFile.name === file) {
+        setSelectedFile(null);
+        setSelectedFileName("File Upload"); 
+        const inputElement = document.getElementById("fileUpload");
+        if (inputElement) {
+          inputElement.value = ""; 
+        }
+      }
+      return updatedFiles;
+    });
+  };
+  
+  const truncateName = (fileName, maxLength = 70) => {
+    if (fileName.length <= maxLength) return fileName;
+    const truncated = fileName.substring(0, maxLength - 3);
+    return `${truncated}...`;
   };
 
   const onSubmit = () => {
-    if (!selectedFile) {
+    if (!filePaths.length) {
       alert("Please select a file.");
       return;
     }
 
     const data = {
-      file_path: fileName.toString(),
+      file_path: selectedFileName.toString(),
       search_terms: searchTerms.split(","),
       sections: sections.split(","),
       specify_lines: specifyLines.toString(),
@@ -77,13 +116,13 @@ const GaussianDashboardComponent = () => {
   };
 
   const fetchDocumentPreview = () => {
-    if (!selectedFile) {
+    if (!selectedFile.length) {
       alert("Please select a file.");
       return;
     }
 
     const data = {
-      file_path: fileName.toString(),
+      file_path: selectedFileName.toString(),
       search_terms: searchTerms.split(","),
       sections: sections.split(","),
       specify_lines: specifyLines.toString(),
@@ -113,13 +152,37 @@ const GaussianDashboardComponent = () => {
       <div className="text-center">
         <h2 className="mb-4">Extract data from Gaussian files to Word documents</h2>
         <div className="mb-3 text-start">
-          <span>Upload your Gaussian data file</span>
+        <label htmlFor="fileUpload" className="mb-2">
+          Upload your Gaussian data file
+          </label>
           <div className="input-group">
-            <input type="file" className="form-control" onChange={onFileSelected} accept=".log" />
+            <input
+             className="form-control" 
+             type="file" 
+             id="fileUpload"
+             onChange={onFileSelected} 
+             accept=".log" 
+             multiple
+             aria-label="Upload Gaussian data file"
+            />
             <button className="btn btn-primary" onClick={onUpload}>
               Upload
             </button>
           </div>
+        </div>
+
+        <div className="mb-3 text-start">
+          <label>Uploaded Files:</label>
+          {uploadedFiles.map((file, index) => (
+            <span key={index} className="badge bg-secondary ms-1 me-1 mb-2">
+              {truncateName(file, 40)}
+              <button
+                type="button"
+                className="btn-close ms-1"
+                aria-label="Remove"
+                onClick={() => removeUploadedFile(file)}></button>
+            </span>
+          ))}
         </div>
 
         <div className="mb-3 text-start">

--- a/server/usecases/upload_files.py
+++ b/server/usecases/upload_files.py
@@ -8,7 +8,7 @@ def file_upload_use_case(file):
     if file.filename == '':
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, 'No selected file')
 
-    if file.mimetype != 'text/plain':
+    if file.mimetype != 'text/plain' and not file.filename.lower().endswith('.log'):
         return ResponseFailure(ResponseTypes.PARAMETER_ERROR, 'Invalid file type')
 
     try:


### PR DESCRIPTION
Fixes #161

**What was changed?**

- Implemented the file upload functionality for Gaussian .log files in the GaussianDashboardComponent.js, mirroring the ORCA file upload approach.

- Validates that selected files end with .log, prevents duplicate uploads, and clears the file input after successful upload.

**Why was it changed?**

- According to the acceptance criteria, the Gaussian Log Extraction tab needs the same upload workflow as ORCA, but specifically for .log files.

- Before this change, users could not properly upload .log files in the Gaussian tab, blocking further log extraction steps.

**How was it changed?**

- Replicates ORCA’s multiple-file handling logic in the Gaussian dashboard, ensuring .log files are recognized, validated, and passed to the server similarly to .txt files on the ORCA side.

- Adds checks for invalid/unsupported files (non-.log) and duplicate filenames, consistent with the existing ORCA workflow.

**Screenshots that show the changes (if applicable):**
![image](https://github.com/user-attachments/assets/485536d7-9dfc-4466-8390-b97f3239c64d)
