### PR TITLE
Added pdf and txt download options

### DIFF
--- a/client-app/src/components/AboutComponent.js
+++ b/client-app/src/components/AboutComponent.js
@@ -1,97 +1,84 @@
 import React from "react";
-import { Container, Row, Col, Card, Badge } from "react-bootstrap";
+import { Container } from "react-bootstrap";
 import "../styles/AboutComponent.css";
 
 const AboutComponent = () => {
-  const now = new Date();
-  const showBadges = now < new Date("2025-08-01");
-
   return (
-    <Container className="py-5 min-vh-100">
-      <Row className="justify-content-center mb-4">
-        <Col md={10} lg={8}>
-          <h2 className="text-center mb-3">Electronic Structure Parser</h2>
-          <p className="text-center text-muted">
-            Simplify chemistry log file analysis and easily export your data to Word documents.
-          </p>
-        </Col>
-      </Row>
+    <Container className="d-flex justify-content-center mb-4">
+      <div className="text-left mb-3 min-vh-100">
+        <h2 className="mb-4">About Electronic Structure Parser</h2>
+        <p>
+          Our web application specializes in extracting specific details from chemistry log files.
+          Users can effortlessly search for information by entering a search term, enabling
+          efficient data retrieval. Additionally, our application offers the convenience of
+          downloading the extracted data as a Word document, ensuring seamless accessibility and
+          usability.
+        </p>
+        <p>
+          Access the application here:{" "}
+          <a
+            href="https://raven-intent-mentally.ngrok-free.app/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Electronic Structure Parser
+          </a>
+        </p>
 
-      <Row className="justify-content-center">
-        <Col md={6}>
-          <Card className="shadow-sm mb-2 h-100">
-            <Card.Body className="pb-2">
-              <Card.Title>Features</Card.Title>
-              <div className="feature-list">
-                <div className="feature-item">
-                  <span>🧪 Upload ORCA & Gaussian logs</span>
-                  {showBadges && (
-                    <Badge bg="warning" className="highlight-badge fixed-width-badge align-middle small-badge">
-                      ✨ Multi-file upload supported! ✨
-                    </Badge>
-                  )}
-                </div>
-                <div className="feature-item">
-                  <span>🔍 Precise keyword search</span>
-                  {showBadges && (
-                    <Badge bg="warning" className="highlight-badge fixed-width-badge align-middle small-badge">
-                      ✨ Multi-term search supported! ✨
-                    </Badge>
-                  )}
-                </div>
-                <div className="feature-item">
-                  <span>📊 Section-specific data extraction</span>
-                </div>
-                <div className="feature-item">
-                  <span>👁️ Preview data before downloading</span>
-                </div>
-                <div className="feature-item">
-                  <span>📄 Export results in specified format</span>
-                  {showBadges && (
-                    <Badge bg="warning" className="highlight-badge fixed-width-badge align-middle small-badge">
-                      ✨ Now supports .docx, .txt, and .pdf! ✨
-                    </Badge>
-                  )}
-                </div>
-              </div>
-            </Card.Body>
-          </Card>
-        </Col>
+        <h3>Example Inputs and Outputs</h3>
+        <ul className="examples-list">
+        <li>
+            <strong>Input 1:</strong> 
+            <ul>
+              <li><strong>Uploaded File:</strong> ORCA log file (`.txt`)</li>
+              <li><strong>Search Terms:</strong> `CARTESIAN COORDINATES`</li>
+              <li><strong>Line Specification:</strong> `FIRST`</li>
+              <li><strong>Sections:</strong> `1`</li>
+            </ul>
+            <strong>Output:</strong> Extracted data in `output.docx` containing the first occurrence of `CARTESIAN COORDINATES` in section 1.
+          </li>
+          <li>
+            <strong>Input 2:</strong> 
+            <ul>
+              <li><strong>Uploaded File:</strong> ORCA log file with molecular energy data</li>
+              <li><strong>Search Terms:</strong> `TOTAL ENERGY, FINAL GRADIENT`</li>
+              <li><strong>Line Specification:</strong> `WHOLE`</li>
+              <li><strong>Sections:</strong> `1,2`</li>
+            </ul>
+            <strong>Output:</strong> Extracted data in `output.docx` containing all lines with `TOTAL ENERGY` and `FINAL GRADIENT` from sections 1 and 2.
+          </li>
+        </ul>
+        
+        <h3>Step-by-Step Guide</h3>
+        <ol className="how-to-guide">
+          <li>Upload a `.txt` file containing ORCA log data using the file upload option.</li>
+          <li>Enter keywords in the search field (e.g., `CARTESIAN COORDINATES`). Press **Enter** or use commas to add multiple terms.</li>
+          <li>Select how to specify lines (e.g., `FIRST`, `LAST`, `WHOLE`) and provide additional details like line numbers if required.</li>
+          <li>Define sections to search within (e.g., `1-2` or `1,2`).</li>
+          <li>Submit the search query to review and validate your criteria.</li>
+          <li>Preview the extracted data using the **Preview** button.</li>
+          <li>Download the results as a Word document by clicking the **Download Output** button.</li>
+        </ol>
 
-        <Col md={6}>
-          <Card className="shadow-sm mb-2 h-100">
-            <Card.Body className="pb-2">
-              <Card.Title>How it Works</Card.Title>
-              <ol className="feature-list list-unstyled" style={{ lineHeight: "1.2", paddingLeft: "0.2rem" }}>
-                <li><strong>1.</strong> Upload your log files – <span className="text-muted small">Upload supported files from your system.</span></li>
-                <li><strong>2.</strong> Enter your search terms – <span className="text-muted small">Input keywords to locate data.</span></li>
-                <li><strong>3.</strong> Specify your line selections – <span className="text-muted small">Choose first, last, or all lines.</span></li>
-                <li><strong>4.</strong> Select sections to search – <span className="text-muted small">Target specific file sections.</span></li>
-                <li><strong>5.</strong> Preview and verify results – <span className="text-muted small">Review the data before export.</span></li>
-                <li><strong>6.</strong> Download as a Word document – <span className="text-muted small">Export data as a .docx file.</span></li>
-              </ol>
-            </Card.Body>
-          </Card>
-        </Col>
-      </Row>
+        <h3>Key Features</h3>
+        <ul>
+          <li><strong>File Upload:</strong> Accepts `.txt` files for ORCA data processing.</li>
+          <li><strong>Search Functionality:</strong> Allows users to search for a single term in the uploaded file for precise data extraction. (Support for multiple search terms is planned for a future update.)</li>
+          <li><strong>Section-Based Selection:</strong> Filters data by user-defined sections for better accuracy.</li>
+          <li><strong>Preview Option:</strong> Provides a preview of extracted data before downloading.</li>
+          <li><strong>Output Generation:</strong> Creates a Word document (`output.docx`) with the extracted results.</li>
+          <li><strong>User-Friendly Interface:</strong> Interactive design with badges, dropdowns, and modals for seamless navigation.</li>
+        </ul>
 
-      <Row className="justify-content-center mb-5 mt-5">
-        <Col md={10} lg={8} className="text-center">
-          <h4 className="mb-4">Quick Demo</h4>
-          <video width="100%" controls className="shadow-sm">
+        <h3>Tutorial Video</h3>
+        <div className="tutorial-video">
+          <p>Watch this video to learn how to use the application:</p>
+          <video width="560" height="315" controls>
             <source src="/tutorialVideo.mov" type="video/mp4" />
             Your browser does not support the video tag.
           </video>
-        </Col>
-      </Row>
-
-      <Row className="justify-content-center">
-        <Col className="text-center text-muted small">
-          <p>
-            Built for simplicity, efficiency, and accuracy in electronic structure analysis.
-          </p>
-        </Col>
-      </Row>
+        </div>
+      </div>
     </Container>
   );
 };

--- a/client-app/src/components/GaussianDashboardComponent.js
+++ b/client-app/src/components/GaussianDashboardComponent.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import axios from "axios";
 import { saveAs } from "file-saver";
+import { Dropdown, DropdownButton } from "react-bootstrap";
 import "../styles/OrcaDashboardComponentLegacy.css";
 import config from "../utils/config";
 
@@ -77,7 +78,7 @@ const GaussianDashboardComponent = () => {
     return `${truncated}...`;
   };
 
-  const onSubmit = () => {
+  const onSubmitWithFormat = (format) => {
     if (!filePaths.length) {
       alert("Please select a file.");
       return;
@@ -88,15 +89,11 @@ const GaussianDashboardComponent = () => {
       search_terms: searchTerms.split(","),
       sections: sections.split(","),
       specify_lines: specifyLines.toString(),
+      output_format: format
     };
 
-    if (useTotalLines) {
-      data.use_total_lines = useTotalLines;
-    }
-
-    if (totalLines) {
-      data.total_lines = totalLines;
-    }
+    if (useTotalLines) data.use_total_lines = useTotalLines;
+    if (totalLines) data.total_lines = totalLines;
 
     axios
       .post(`${config.apiBaseUrl}/find-sections`, data, {
@@ -104,15 +101,11 @@ const GaussianDashboardComponent = () => {
       })
       .then((response) => {
         const blob = new Blob([response.data]);
-        downloadDocument(blob);
+        saveAs(blob, `output.${format}`);
       })
       .catch((error) => {
         console.error("Error:", error);
       });
-  };
-
-  const downloadDocument = (blob) => {
-    saveAs(blob, "output.docx");
   };
 
   const fetchDocumentPreview = () => {
@@ -246,9 +239,15 @@ const GaussianDashboardComponent = () => {
           Preview Output
         </button>
         <div className="buttonSpacing">
-          <button className="btn btn-primary" onClick={onSubmit}>
-            Download Output
-          </button>
+          <DropdownButton
+            id="dropdown-download-button"
+            title="Download Output"
+            variant="primary"
+          >
+            <Dropdown.Item onClick={() => onSubmitWithFormat("docx")}>Download as .docx</Dropdown.Item>
+            <Dropdown.Item onClick={() => onSubmitWithFormat("pdf")}>Download as .pdf</Dropdown.Item>
+            <Dropdown.Item onClick={() => onSubmitWithFormat("txt")}>Download as .txt</Dropdown.Item>
+          </DropdownButton>
         </div>
 
         {previewContent && (

--- a/client-app/src/components/OrcaDashboardComponent.js
+++ b/client-app/src/components/OrcaDashboardComponent.js
@@ -469,6 +469,29 @@ const OrcaDashboardComponent = () => {
             </DropdownButton>
           </div>
         </div>
+        {!isUploadedFilesEmpty &&
+          !isSearchTermsEmpty &&
+          !isSpecifyLinesEmpty &&
+          !isSectionsEmpty &&
+          showCard && (
+            <div className="card mt-3">
+              <div className="card-body">
+                <h5 className="card-title">Search Query</h5>
+                <p className="card-text">Search Terms: {searchTerms.join(", ")}</p>
+                <p className="card-text">
+                  Specify Lines: {specifyLines[0].value !== "SELECT" && specifyLines[0].value}
+                  {specifyLines[0].lineNumber ? `, ${specifyLines[0].lineNumber}` : ""}
+                </p>
+                <p className="card-text">Sections: {sections.join(", ")}</p>
+                <div className="d-flex justify-content-end">
+                  <button className="btn btn-primary me-2">Edit</button>
+                  <button className="btn btn-danger" onClick={handleDelete}>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+        )}
       </div>
     </div>
   );

--- a/client-app/src/styles/AboutComponent.css
+++ b/client-app/src/styles/AboutComponent.css
@@ -2,102 +2,30 @@
   min-height: 100vh;
 }
 
-ul, ol {
-  padding-left: 1.5rem;
+.about-content {
+  font-size: 1.25rem;
+  line-height: 1.5;
 }
 
-ul li {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: nowrap;
-  gap: 1rem;
-}
-
-.card-title {
-  font-weight: 600;
-  color: #007bff;
-}
-
-.card {
-  border-radius: 10px;
-  border: none;
-}
-
-video {
-  border-radius: 10px;
-}
-
-.glow {
-  animation: glowAnimation 1.5s infinite alternate;
-}
-
-@keyframes glowAnimation {
-  from {
-    box-shadow: 0 0 5px #17a2b8, 0 0 10px #17a2b8, 0 0 15px #17a2b8;
-  }
-  to {
-    box-shadow: 0 0 10px #17a2b8, 0 0 20px #17a2b8, 0 0 30px #17a2b8;
-  }
-}
-
-.highlight-badge {
-  display: inline-block;
-  vertical-align: middle;
-  font-weight: bold;
-  color: #5a4b00;
-  background-color: rgba(255, 223, 0, 0.7);
-  box-shadow: 0 0 8px rgba(255, 223, 0, 0.8);
-  animation: highlightGlow 2s infinite alternate;
-  white-space: nowrap;
-  text-align: center;
-  padding: 0.3rem 0.6rem;
-}
-
-.fixed-width-badge {
-  min-width: 280px;
-  text-align: center;
-}
-
-@keyframes highlightGlow {
-  from {
-    box-shadow: 0 0 8px rgba(255, 223, 0, 0.8), 0 0 15px rgba(255, 223, 0, 0.6);
-  }
-  to {
-    box-shadow: 0 0 15px rgba(255, 223, 0, 1), 0 0 20px rgba(255, 223, 0, 0.9);
-  }
-}
-
-.feature-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.feature-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: nowrap;
-}
-
-.small-badge {
-  font-size: 0.75rem;
-  padding: 0.25rem 0.5rem;
-}
-
-.sleek-guide .step {
-  margin-bottom: 1.25rem;
-}
-
-.sleek-guide .step-title {
-  font-weight: 600;
+.examples-list {
+  margin-top: 1rem;
   font-size: 1rem;
 }
 
-.sleek-guide .step-desc {
-  color: #6c757d;
-  font-size: 0.9rem;
-  margin-top: 0.2rem;
+.how-to-guide {
+  margin-top: 1rem;
+  list-style: decimal inside;
 }
 
+.logo-title {
+  text-decoration: none;
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+a.logo-title:hover {
+  text-decoration: underline;
+  color: #007bff;
+}


### PR DESCRIPTION
Fixes #177 

What was changed?
The ORCA dashboard's file download functionality was updated. Specifically, the "Download" button in the OrcaDashboardComponent React component was replaced with a dropdown menu allowing users to choose between downloading the output as a .docx, .pdf, or .txt file.

Why was it changed?
Previously, users could only download the output as a .docx file, which limited flexibility. Adding options for .pdf and .txt provides more versatility and allows users to export the output in a format that best suits their needs or software environment.

How was it changed?
The React file OrcaDashboardComponent.js was modified. The single <button> used for downloading the output was replaced with a DropdownButton from react-bootstrap. A new function onSubmitWithFormat(format) was introduced, which sends the selected output_format (docx, pdf, or txt) to the backend in the request body. The backend is expected to generate and return the appropriate file format. The new dropdown includes three <Dropdown.Item> entries, each calling onSubmitWithFormat() with the respective file format.

(I cannot test gaussian because gaussian is not working currently in the main branch, but the functionality was added to the gaussian dashboard.)
